### PR TITLE
Parser: Support for Decimal Number

### DIFF
--- a/pesca_parser_derive/src/token.rs
+++ b/pesca_parser_derive/src/token.rs
@@ -52,7 +52,6 @@ pub fn impl_token_macro(ast: syn::DeriveInput) -> TokenStream {
         })
         .collect::<Vec<_>>();
 
-    // TODO: use this variants in a way to automatically parse them.
     let literal_variants_tuples = variants
         .clone()
         .into_iter()

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -17,6 +17,8 @@ pub enum Token {
     Id { value: String, position: Position },
     #[literal("[0-9]+")]
     Integer { value: u64, position: Position },
+    #[literal("[0-9]+\\.[0-9]+")]
+    FloatingPoint { value: f64, position: Position },
     #[terminal(";")]
     Semicolon { position: Position },
     #[literal("//.*")]

--- a/src/parser/ast/expression/array.rs
+++ b/src/parser/ast/expression/array.rs
@@ -88,7 +88,10 @@ mod tests {
         let result = Array::parse(&mut tokens);
         assert_eq!(
             Ok(Array::Literal {
-                values: vec![Expression::Num(Num(42)), Expression::Num(Num(1337))]
+                values: vec![
+                    Expression::Num(Num::Integer(42)),
+                    Expression::Num(Num::Integer(1337))
+                ]
             }
             .into()),
             result
@@ -105,8 +108,8 @@ mod tests {
         let result = Array::parse(&mut tokens);
         assert_eq!(
             Ok(Array::Default {
-                initial_value: Box::new(Expression::Num(Num(42))),
-                length: Num(5)
+                initial_value: Box::new(Expression::Num(Num::Integer(42))),
+                length: Num::Integer(5)
             }
             .into()),
             result

--- a/src/parser/ast/expression/block.rs
+++ b/src/parser/ast/expression/block.rs
@@ -92,7 +92,7 @@ mod tests {
                     Statement::Initialization(Initialisation {
                         id: Id("a".into()),
                         mutable: false,
-                        value: Expression::Num(Num(42)),
+                        value: Expression::Num(Num::Integer(42)),
                         type_name: None
                     },),
                     Statement::YieldingExpression(Expression::Id(Id("a".into())))

--- a/src/parser/ast/expression/if_expression.rs
+++ b/src/parser/ast/expression/if_expression.rs
@@ -123,8 +123,8 @@ mod tests {
             Ok(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
                 statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(3))),
-                    Box::new(Expression::Num(Num(4)))
+                    Box::new(Expression::Num(Num::Integer(3))),
+                    Box::new(Expression::Num(Num::Integer(4)))
                 ))],
                 else_statements: vec![]
             }
@@ -144,12 +144,12 @@ mod tests {
             Ok(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
                 statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(3))),
-                    Box::new(Expression::Num(Num(4)))
+                    Box::new(Expression::Num(Num::Integer(3))),
+                    Box::new(Expression::Num(Num::Integer(4)))
                 ))],
                 else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(42))),
-                    Box::new(Expression::Num(Num(1337)))
+                    Box::new(Expression::Num(Num::Integer(42))),
+                    Box::new(Expression::Num(Num::Integer(1337)))
                 ))],
             }
             .into()),

--- a/src/parser/ast/expression/lambda.rs
+++ b/src/parser/ast/expression/lambda.rs
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(
             Ok(Lambda {
                 parameters: vec![],
-                expression: Box::new(Expression::Num(Num(42)))
+                expression: Box::new(Expression::Num(Num::Integer(42)))
             }
             .into()),
             result

--- a/src/parser/ast/expression/mod.rs
+++ b/src/parser/ast/expression/mod.rs
@@ -303,7 +303,7 @@ mod tests {
 
         assert_eq!(
             Expression::parse(&mut tokens.into()),
-            Ok(AstNode::Expression(Expression::Num(Num(42))))
+            Ok(AstNode::Expression(Expression::Num(Num::Integer(42))))
         )
     }
 
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(
             Ok(Expression::Lambda(Lambda {
                 parameters: vec![],
-                expression: Box::new(Expression::Num(Num(42)))
+                expression: Box::new(Expression::Num(Num::Integer(42)))
             })
             .into()),
             result
@@ -428,12 +428,12 @@ mod tests {
             Ok(Expression::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
                 statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(3))),
-                    Box::new(Expression::Num(Num(4)))
+                    Box::new(Expression::Num(Num::Integer(3))),
+                    Box::new(Expression::Num(Num::Integer(4)))
                 ))],
                 else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(42))),
-                    Box::new(Expression::Num(Num(1337)))
+                    Box::new(Expression::Num(Num::Integer(42))),
+                    Box::new(Expression::Num(Num::Integer(1337)))
                 ))],
             })
             .into()),
@@ -484,7 +484,10 @@ mod tests {
                         Box::new(Expression::Id(Id("y".into())))
                     ))
                 })))),
-                args: vec![Expression::Num(Num(42)), Expression::Num(Num(1337))]
+                args: vec![
+                    Expression::Num(Num::Integer(42)),
+                    Expression::Num(Num::Integer(1337))
+                ]
             })
             .into()),
             result
@@ -512,7 +515,10 @@ mod tests {
         let result = Expression::parse(&mut tokens);
         assert_eq!(
             Ok(Expression::Array(Array::Literal {
-                values: vec![Expression::Num(Num(42)), Expression::Num(Num(1337))]
+                values: vec![
+                    Expression::Num(Num::Integer(42)),
+                    Expression::Num(Num::Integer(1337))
+                ]
             })
             .into()),
             result
@@ -531,7 +537,7 @@ mod tests {
         assert_eq!(
             Ok(Expression::Postfix(Postfix::Index {
                 expr: Box::new(Expression::Id(Id("foo".into()))),
-                index: Box::new(Expression::Num(Num(42)))
+                index: Box::new(Expression::Num(Num::Integer(42)))
             })
             .into()),
             result
@@ -553,7 +559,7 @@ mod tests {
                 fields: vec![
                     StructFieldInitialisation {
                         name: Id("bar".into()),
-                        value: Expression::Num(Num(42))
+                        value: Expression::Num(Num::Integer(42))
                     },
                     StructFieldInitialisation {
                         name: Id("baz".into()),
@@ -624,7 +630,7 @@ mod tests {
 
         assert_eq!(
             Ok(Expression::Prefix(Prefix::Minus {
-                expr: Box::new(Expression::Num(Num(42)))
+                expr: Box::new(Expression::Num(Num::Integer(42)))
             })
             .into()),
             result
@@ -660,7 +666,7 @@ mod tests {
 
         assert_eq!(
             Ok(Expression::Prefix(Prefix::Negation {
-                expr: Box::new(Expression::Num(Num(42)))
+                expr: Box::new(Expression::Num(Num::Integer(42)))
             })
             .into()),
             result

--- a/src/parser/ast/expression/struct_initialisation.rs
+++ b/src/parser/ast/expression/struct_initialisation.rs
@@ -98,7 +98,7 @@ mod tests {
         assert_eq!(
             Ok(StructFieldInitialisation {
                 name: Id("bar".into()),
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             }
             .into()),
             result
@@ -138,7 +138,7 @@ mod tests {
                 id: Id("Foo".into()),
                 fields: vec![StructFieldInitialisation {
                     name: Id("bar".into()),
-                    value: Expression::Num(Num(42))
+                    value: Expression::Num(Num::Integer(42))
                 }]
             }
             .into()),
@@ -161,7 +161,7 @@ mod tests {
                 fields: vec![
                     StructFieldInitialisation {
                         name: Id("bar".into()),
-                        value: Expression::Num(Num(42))
+                        value: Expression::Num(Num::Integer(42))
                     },
                     StructFieldInitialisation {
                         name: Id("baz".into()),

--- a/src/parser/ast/statement/constant.rs
+++ b/src/parser/ast/statement/constant.rs
@@ -71,7 +71,7 @@ mod tests {
             Ok(Constant {
                 id: Id("foo".into()),
                 type_name: TypeName::Literal("i32".into()),
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             }
             .into()),
             result

--- a/src/parser/ast/statement/initialisation.rs
+++ b/src/parser/ast/statement/initialisation.rs
@@ -91,7 +91,7 @@ mod tests {
                 id: Id("foo".into()),
                 mutable: false,
                 type_name: None,
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             }
             .into()),
             result
@@ -112,7 +112,7 @@ mod tests {
                 id: Id("foo".into()),
                 mutable: false,
                 type_name: Some(TypeName::Literal("i32".into())),
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             }
             .into()),
             result
@@ -133,7 +133,7 @@ mod tests {
                 id: Id("foo".into()),
                 mutable: true,
                 type_name: None,
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             }
             .into()),
             result

--- a/src/parser/ast/statement/mod.rs
+++ b/src/parser/ast/statement/mod.rs
@@ -206,7 +206,7 @@ mod tests {
             Ok(Statement::Constant(Constant {
                 id: Id("foo".into()),
                 type_name: TypeName::Literal("i32".into()),
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             })
             .into()),
             result
@@ -220,7 +220,7 @@ mod tests {
         let result = Statement::parse(&mut tokens);
 
         assert_eq!(
-            Ok(Statement::Return(Expression::Num(Num(42))).into()),
+            Ok(Statement::Return(Expression::Num(Num::Integer(42))).into()),
             result
         );
     }
@@ -238,12 +238,12 @@ mod tests {
             Ok(Statement::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
                 statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(3))),
-                    Box::new(Expression::Num(Num(4)))
+                    Box::new(Expression::Num(Num::Integer(3))),
+                    Box::new(Expression::Num(Num::Integer(4)))
                 ))],
                 else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(42))),
-                    Box::new(Expression::Num(Num(1337)))
+                    Box::new(Expression::Num(Num::Integer(42))),
+                    Box::new(Expression::Num(Num::Integer(1337)))
                 ))],
             })
             .into()),
@@ -264,12 +264,12 @@ mod tests {
             Ok(Statement::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
                 statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(3))),
-                    Box::new(Expression::Num(Num(4)))
+                    Box::new(Expression::Num(Num::Integer(3))),
+                    Box::new(Expression::Num(Num::Integer(4)))
                 ))],
                 else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(42))),
-                    Box::new(Expression::Num(Num(1337)))
+                    Box::new(Expression::Num(Num::Integer(42))),
+                    Box::new(Expression::Num(Num::Integer(1337)))
                 ))],
             })
             .into()),
@@ -290,12 +290,12 @@ mod tests {
             Ok(Statement::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
                 statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(3))),
-                    Box::new(Expression::Num(Num(4)))
+                    Box::new(Expression::Num(Num::Integer(3))),
+                    Box::new(Expression::Num(Num::Integer(4)))
                 ))],
                 else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num(42))),
-                    Box::new(Expression::Num(Num(1337)))
+                    Box::new(Expression::Num(Num::Integer(42))),
+                    Box::new(Expression::Num(Num::Integer(1337)))
                 ))],
             })
             .into()),
@@ -312,7 +312,7 @@ mod tests {
         assert_eq!(
             Ok(Statement::Assignment(Assignment {
                 id: Id("x".into()),
-                value: Expression::Num(Num(42))
+                value: Expression::Num(Num::Integer(42))
             })
             .into()),
             result

--- a/src/parser/combinators.rs
+++ b/src/parser/combinators.rs
@@ -499,7 +499,7 @@ mod tests {
         .into();
         let result = a.parse(&mut tokens);
 
-        assert_eq!(Ok(vec![AstNode::Num(Num(42))]), result);
+        assert_eq!(Ok(vec![AstNode::Num(Num::Integer(42))]), result);
         assert_eq!(tokens.get_index(), 1);
     }
 
@@ -604,9 +604,9 @@ mod tests {
 
         assert_eq!(
             Ok(vec![
-                AstNode::Num(Num(42)),
-                AstNode::Num(Num(1337)),
-                AstNode::Num(Num(17))
+                AstNode::Num(Num::Integer(42)),
+                AstNode::Num(Num::Integer(1337)),
+                AstNode::Num(Num::Integer(17))
             ]),
             result
         );
@@ -637,9 +637,9 @@ mod tests {
 
         assert_eq!(
             Ok(vec![
-                AstNode::Num(Num(42)),
-                AstNode::Num(Num(1337)),
-                AstNode::Num(Num(17))
+                AstNode::Num(Num::Integer(42)),
+                AstNode::Num(Num::Integer(1337)),
+                AstNode::Num(Num::Integer(17))
             ]),
             result
         );
@@ -666,7 +666,7 @@ mod tests {
         .into();
         let result = a.parse(&mut tokens);
 
-        assert_eq!(Ok(vec![AstNode::Num(Num(42))]), result);
+        assert_eq!(Ok(vec![AstNode::Num(Num::Integer(42))]), result);
         assert_eq!(tokens.get_index(), 1);
     }
 
@@ -682,7 +682,7 @@ mod tests {
         ]
         .into();
         let result = matcher.parse(&mut tokens);
-        assert_eq!(Ok(vec![AstNode::Num(Num(42))]), result);
+        assert_eq!(Ok(vec![AstNode::Num(Num::Integer(42))]), result);
         assert_eq!(tokens.get_index(), 2);
     }
 
@@ -696,7 +696,7 @@ mod tests {
         .into();
         let result = matcher.parse(&mut tokens);
 
-        assert_eq!(Ok(vec![AstNode::Num(Num(42))]), result);
+        assert_eq!(Ok(vec![AstNode::Num(Num::Integer(42))]), result);
         assert_eq!(tokens.get_index(), 1);
 
         let mut tokens = vec![Token::Id {


### PR DESCRIPTION
This PR adds support for parsing decimal (i.e., floating point numbers). 

Closes #23 