### PR TITLE
Parser: Operator Precedence

### DIFF
--- a/src/parser/ast/expression/binary.rs
+++ b/src/parser/ast/expression/binary.rs
@@ -1,0 +1,24 @@
+use super::{ComparisonOperation, Expression};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinaryExpression {
+    Addition(Expression, Expression),
+    Substraction(Expression, Expression),
+    Multiplication(Expression, Expression),
+    Division(Expression, Expression),
+    Comparison {
+        lhs: Expression,
+        rhs: Expression,
+        operation: ComparisonOperation,
+    },
+}
+
+impl BinaryExpression {
+    pub fn precedence(&self) -> usize {
+        match self {
+            BinaryExpression::Addition(_, _) | BinaryExpression::Substraction(_, _) => 1,
+            BinaryExpression::Multiplication(_, _) | BinaryExpression::Division(_, _) => 2,
+            BinaryExpression::Comparison { .. } => 0,
+        }
+    }
+}

--- a/src/parser/ast/expression/binary.rs
+++ b/src/parser/ast/expression/binary.rs
@@ -16,29 +16,29 @@ pub enum BinaryExpression {
 impl BinaryExpression {
     pub fn inner(&self) -> (Expression, Expression) {
         match self {
-            BinaryExpression::Addition(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::Substraction(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::Multiplication(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::Division(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::Equal(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::GreaterThan(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::LessThen(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::GreaterOrEqual(lhs, rhs) => (lhs.clone(), rhs.clone()),
-            BinaryExpression::LessOrEqual(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::Addition(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::Substraction(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::Multiplication(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::Division(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::Equal(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::GreaterThan(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::LessThen(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::GreaterOrEqual(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            Self::LessOrEqual(lhs, rhs) => (lhs.clone(), rhs.clone()),
         }
     }
 
     pub fn converter(&self) -> impl Fn(Expression, Expression) -> BinaryExpression {
         match self {
-            BinaryExpression::Addition(_, _) => BinaryExpression::Addition,
-            BinaryExpression::Substraction(_, _) => BinaryExpression::Substraction,
-            BinaryExpression::Multiplication(_, _) => BinaryExpression::Multiplication,
-            BinaryExpression::Division(_, _) => BinaryExpression::Division,
-            BinaryExpression::Equal(_, _) => BinaryExpression::Equal,
-            BinaryExpression::GreaterThan(_, _) => BinaryExpression::GreaterThan,
-            BinaryExpression::LessThen(_, _) => BinaryExpression::LessThen,
-            BinaryExpression::GreaterOrEqual(_, _) => BinaryExpression::GreaterOrEqual,
-            BinaryExpression::LessOrEqual(_, _) => BinaryExpression::LessOrEqual,
+            Self::Addition(_, _) => BinaryExpression::Addition,
+            Self::Substraction(_, _) => BinaryExpression::Substraction,
+            Self::Multiplication(_, _) => BinaryExpression::Multiplication,
+            Self::Division(_, _) => BinaryExpression::Division,
+            Self::Equal(_, _) => BinaryExpression::Equal,
+            Self::GreaterThan(_, _) => BinaryExpression::GreaterThan,
+            Self::LessThen(_, _) => BinaryExpression::LessThen,
+            Self::GreaterOrEqual(_, _) => BinaryExpression::GreaterOrEqual,
+            Self::LessOrEqual(_, _) => BinaryExpression::LessOrEqual,
         }
     }
 

--- a/src/parser/ast/expression/binary.rs
+++ b/src/parser/ast/expression/binary.rs
@@ -1,4 +1,4 @@
-use super::{ComparisonOperation, Expression};
+use super::Expression;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinaryExpression {
@@ -6,19 +6,115 @@ pub enum BinaryExpression {
     Substraction(Expression, Expression),
     Multiplication(Expression, Expression),
     Division(Expression, Expression),
-    Comparison {
-        lhs: Expression,
-        rhs: Expression,
-        operation: ComparisonOperation,
-    },
+    Equal(Expression, Expression),
+    GreaterThan(Expression, Expression),
+    LessThen(Expression, Expression),
+    GreaterOrEqual(Expression, Expression),
+    LessOrEqual(Expression, Expression),
 }
 
 impl BinaryExpression {
-    pub fn precedence(&self) -> usize {
+    pub fn inner(&self) -> (Expression, Expression) {
         match self {
-            BinaryExpression::Addition(_, _) | BinaryExpression::Substraction(_, _) => 1,
-            BinaryExpression::Multiplication(_, _) | BinaryExpression::Division(_, _) => 2,
-            BinaryExpression::Comparison { .. } => 0,
+            BinaryExpression::Addition(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::Substraction(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::Multiplication(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::Division(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::Equal(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::GreaterThan(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::LessThen(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::GreaterOrEqual(lhs, rhs) => (lhs.clone(), rhs.clone()),
+            BinaryExpression::LessOrEqual(lhs, rhs) => (lhs.clone(), rhs.clone()),
         }
+    }
+
+    pub fn converter(&self) -> impl Fn(Expression, Expression) -> BinaryExpression {
+        match self {
+            BinaryExpression::Addition(_, _) => BinaryExpression::Addition,
+            BinaryExpression::Substraction(_, _) => BinaryExpression::Substraction,
+            BinaryExpression::Multiplication(_, _) => BinaryExpression::Multiplication,
+            BinaryExpression::Division(_, _) => BinaryExpression::Division,
+            BinaryExpression::Equal(_, _) => BinaryExpression::Equal,
+            BinaryExpression::GreaterThan(_, _) => BinaryExpression::GreaterThan,
+            BinaryExpression::LessThen(_, _) => BinaryExpression::LessThen,
+            BinaryExpression::GreaterOrEqual(_, _) => BinaryExpression::GreaterOrEqual,
+            BinaryExpression::LessOrEqual(_, _) => BinaryExpression::LessOrEqual,
+        }
+    }
+
+    /// This function balances a binary expresion according the precedence of the operators.
+    ///
+    /// Attetention: This function assumes the left hand side to be a non-binary expression!
+    pub fn balance(&self) -> BinaryExpression {
+        let converter = self.converter();
+        let (mut lhs, mut rhs) = self.inner();
+
+        if let Expression::Binary(rhs_binary) = rhs {
+            let precedence = rhs_binary.precedence();
+            let (inner_lhs, inner_rhs) = rhs_binary.inner();
+            let inner_converter = rhs_binary.converter();
+
+            if precedence < self.precedence() {
+                lhs = Expression::Binary(Box::new(converter(lhs, inner_lhs).balance()));
+                rhs = inner_rhs;
+                return inner_converter(lhs, rhs);
+            }
+        }
+        self.clone()
+    }
+
+    pub fn precedence(&self) -> usize {
+        use BinaryExpression::*;
+
+        match self {
+            Addition(_, _) | Substraction(_, _) => 1,
+            Multiplication(_, _) | Division(_, _) => 2,
+            Equal(_, _)
+            | GreaterThan(_, _)
+            | LessThen(_, _)
+            | GreaterOrEqual(_, _)
+            | LessOrEqual(_, _) => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::ast::{Expression, Num};
+
+    use super::BinaryExpression;
+
+    #[test]
+    fn test_simple_balance() {
+        let testee = BinaryExpression::Multiplication(
+            Expression::Num(Num::Integer(42)),
+            Expression::Binary(Box::new(BinaryExpression::Addition(
+                Expression::Num(Num::Integer(1)),
+                Expression::Num(Num::Integer(2)),
+            ))),
+        );
+
+        let expected = BinaryExpression::Addition(
+            Expression::Binary(Box::new(BinaryExpression::Multiplication(
+                Expression::Num(Num::Integer(42)),
+                Expression::Num(Num::Integer(1)),
+            ))),
+            Expression::Num(Num::Integer(2)),
+        );
+
+        assert_eq!(expected, testee.balance());
+    }
+
+    #[test]
+    fn test_unneeded_balance() {
+        let testee = BinaryExpression::Addition(
+            Expression::Binary(Box::new(BinaryExpression::Multiplication(
+                Expression::Num(Num::Integer(42)),
+                Expression::Num(Num::Integer(1)),
+            ))),
+            Expression::Num(Num::Integer(2)),
+        );
+
+        assert_eq!(testee, testee.balance());
     }
 }

--- a/src/parser/ast/expression/function.rs
+++ b/src/parser/ast/expression/function.rs
@@ -114,7 +114,10 @@ impl From<Parameter> for AstNode {
 
 #[cfg(test)]
 mod tests {
-    use crate::{lexer::Lexer, parser::ast::Expression};
+    use crate::{
+        lexer::Lexer,
+        parser::ast::{BinaryExpression, Expression},
+    };
 
     use super::*;
 
@@ -216,10 +219,12 @@ mod tests {
                     }
                 ],
                 return_type: TypeName::Literal("i32".into()),
-                statements: vec![Statement::Return(Expression::Addition(
-                    Box::new(Expression::Id(Id("x".into()))),
-                    Box::new(Expression::Id(Id("y".into()))),
-                ))]
+                statements: vec![Statement::Return(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Id(Id("x".into())),
+                        Expression::Id(Id("y".into())),
+                    )
+                )))]
             }
             .into()),
             result
@@ -249,10 +254,12 @@ mod tests {
                     }
                 ],
                 return_type: TypeName::Literal("i32".into()),
-                statements: vec![Statement::Return(Expression::Addition(
-                    Box::new(Expression::Id(Id("x".into()))),
-                    Box::new(Expression::Id(Id("y".into()))),
-                ))]
+                statements: vec![Statement::Return(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Id(Id("x".into())),
+                        Expression::Id(Id("y".into())),
+                    )
+                )))]
             }
             .into()),
             result

--- a/src/parser/ast/expression/if_expression.rs
+++ b/src/parser/ast/expression/if_expression.rs
@@ -74,7 +74,7 @@ impl From<If> for AstNode {
 mod tests {
     use crate::{
         lexer::Lexer,
-        parser::ast::{Id, Num},
+        parser::ast::{BinaryExpression, Id, Num},
     };
 
     use super::*;
@@ -122,10 +122,12 @@ mod tests {
         assert_eq!(
             Ok(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
-                statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(3))),
-                    Box::new(Expression::Num(Num::Integer(4)))
-                ))],
+                statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(3)),
+                        Expression::Num(Num::Integer(4))
+                    )
+                )))],
                 else_statements: vec![]
             }
             .into()),
@@ -143,14 +145,18 @@ mod tests {
         assert_eq!(
             Ok(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
-                statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(3))),
-                    Box::new(Expression::Num(Num::Integer(4)))
-                ))],
-                else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(42))),
-                    Box::new(Expression::Num(Num::Integer(1337)))
-                ))],
+                statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(3)),
+                        Expression::Num(Num::Integer(4))
+                    )
+                )))],
+                else_statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(42)),
+                        Expression::Num(Num::Integer(1337))
+                    )
+                )))],
             }
             .into()),
             If::parse(&mut tokens)

--- a/src/parser/ast/expression/lambda.rs
+++ b/src/parser/ast/expression/lambda.rs
@@ -54,7 +54,7 @@ impl From<Lambda> for AstNode {
 mod tests {
     use crate::{
         lexer::Lexer,
-        parser::ast::{Block, Id, Num, Statement},
+        parser::ast::{BinaryExpression, Block, Id, Num, Statement},
     };
 
     use super::*;
@@ -99,10 +99,10 @@ mod tests {
                         type_name: None
                     }
                 ],
-                expression: Box::new(Expression::Addition(
-                    Box::new(Expression::Id(Id("x".into()))),
-                    Box::new(Expression::Id(Id("y".into()))),
-                ))
+                expression: Box::new(Expression::Binary(Box::new(BinaryExpression::Addition(
+                    Expression::Id(Id("x".into())),
+                    Expression::Id(Id("y".into())),
+                ))))
             }
             .into()),
             result

--- a/src/parser/ast/expression/mod.rs
+++ b/src/parser/ast/expression/mod.rs
@@ -32,15 +32,6 @@ use crate::{
 use super::AstNode;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ComparisonOperation {
-    Equals,
-    Greater,
-    Less,
-    GreaterOrEquals,
-    LessOrEquals,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expression {
     Id(Id),
     Num(Num),
@@ -48,17 +39,9 @@ pub enum Expression {
     Lambda(Lambda),
     If(If),
     Block(Block),
-    // Addition(Box<Expression>, Box<Expression>),
-    // Substraction(Box<Expression>, Box<Expression>),
-    // Multiplication(Box<Expression>, Box<Expression>),
     Parens(Box<Expression>),
     Postfix(Postfix),
     Prefix(Prefix),
-    // Comparison {
-    //     lhs: Box<Expression>,
-    //     rhs: Box<Expression>,
-    //     operation: ComparisonOperation,
-    // },
     Binary(Box<BinaryExpression>),
     Array(Array),
     StructInitialisation(StructInitialisation),
@@ -165,23 +148,6 @@ impl FromTokens<Token> for Expression {
 }
 
 impl Expression {
-    fn precedence(&self) -> usize {
-        match self {
-            Expression::Binary(binary) => binary.precedence(),
-            Expression::Id(_)
-            | Expression::Num(_)
-            | Expression::Function(_)
-            | Expression::Lambda(_)
-            | Expression::If(_)
-            | Expression::Block(_)
-            | Expression::Parens(_)
-            | Expression::Postfix(_)
-            | Expression::Prefix(_)
-            | Expression::Array(_)
-            | Expression::StructInitialisation(_) => 10,
-        }
-    }
-
     fn parse_call(expr: Expression, tokens: &mut Tokens<Token>) -> Result<Postfix, ParseError> {
         let matcher = Comb::LPAREN >> (Comb::EXPR % Comb::COMMA) >> Comb::RPAREN;
 
@@ -252,35 +218,15 @@ impl Expression {
             Token::Plus { .. } => BinaryExpression::Addition(lhs, rhs),
             Token::Minus { .. } => BinaryExpression::Substraction(lhs, rhs),
             Token::Times { .. } => BinaryExpression::Multiplication(lhs, rhs),
-            Token::Equal { .. } => BinaryExpression::Comparison {
-                lhs,
-                rhs,
-                operation: ComparisonOperation::Equals,
-            },
-            Token::GreaterThan { .. } => BinaryExpression::Comparison {
-                lhs,
-                rhs,
-                operation: ComparisonOperation::Greater,
-            },
-            Token::LessThan { .. } => BinaryExpression::Comparison {
-                lhs,
-                rhs,
-                operation: ComparisonOperation::Less,
-            },
-            Token::GreaterOrEqual { .. } => BinaryExpression::Comparison {
-                lhs,
-                rhs,
-                operation: ComparisonOperation::GreaterOrEquals,
-            },
-            Token::LessOrEqual { .. } => BinaryExpression::Comparison {
-                lhs,
-                rhs,
-                operation: ComparisonOperation::LessOrEquals,
-            },
+            Token::Equal { .. } => BinaryExpression::Equal(lhs, rhs),
+            Token::GreaterThan { .. } => BinaryExpression::GreaterThan(lhs, rhs),
+            Token::LessThan { .. } => BinaryExpression::LessThen(lhs, rhs),
+            Token::GreaterOrEqual { .. } => BinaryExpression::GreaterOrEqual(lhs, rhs),
+            Token::LessOrEqual { .. } => BinaryExpression::LessOrEqual(lhs, rhs),
             _ => unreachable!(),
         };
 
-        Ok(Expression::Binary(Box::new(binary)))
+        Ok(Expression::Binary(Box::new(binary.balance())))
     }
 }
 

--- a/src/parser/ast/expression/struct_initialisation.rs
+++ b/src/parser/ast/expression/struct_initialisation.rs
@@ -79,7 +79,7 @@ mod tests {
     use crate::{
         lexer::Lexer,
         parser::{
-            ast::{Expression, Id, Lambda, Num, Parameter},
+            ast::{BinaryExpression, Expression, Id, Lambda, Num, Parameter},
             FromTokens,
         },
     };
@@ -170,10 +170,12 @@ mod tests {
                                 name: Id("x".into()),
                                 type_name: None
                             }],
-                            expression: Box::new(Expression::Addition(
-                                Box::new(Expression::Id(Id("x".into()))),
-                                Box::new(Expression::Id(Id("x".into())))
-                            ))
+                            expression: Box::new(Expression::Binary(Box::new(
+                                BinaryExpression::Addition(
+                                    Expression::Id(Id("x".into())),
+                                    Expression::Id(Id("x".into()))
+                                )
+                            )))
                         })
                     }
                 ]

--- a/src/parser/ast/statement/mod.rs
+++ b/src/parser/ast/statement/mod.rs
@@ -188,7 +188,7 @@ impl From<Statement> for AstNode {
 mod tests {
     use crate::{
         lexer::Lexer,
-        parser::ast::{Id, Num, TypeName},
+        parser::ast::{BinaryExpression, Id, Num, TypeName},
     };
 
     use super::*;
@@ -237,14 +237,18 @@ mod tests {
         assert_eq!(
             Ok(Statement::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
-                statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(3))),
-                    Box::new(Expression::Num(Num::Integer(4)))
-                ))],
-                else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(42))),
-                    Box::new(Expression::Num(Num::Integer(1337)))
-                ))],
+                statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(3)),
+                        Expression::Num(Num::Integer(4))
+                    )
+                )))],
+                else_statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(42)),
+                        Expression::Num(Num::Integer(1337))
+                    )
+                )))],
             })
             .into()),
             result
@@ -263,14 +267,18 @@ mod tests {
         assert_eq!(
             Ok(Statement::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
-                statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(3))),
-                    Box::new(Expression::Num(Num::Integer(4)))
-                ))],
-                else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(42))),
-                    Box::new(Expression::Num(Num::Integer(1337)))
-                ))],
+                statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(3)),
+                        Expression::Num(Num::Integer(4))
+                    )
+                )))],
+                else_statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(42)),
+                        Expression::Num(Num::Integer(1337))
+                    )
+                )))],
             })
             .into()),
             result
@@ -289,14 +297,18 @@ mod tests {
         assert_eq!(
             Ok(Statement::If(If {
                 condition: Box::new(Expression::Id(Id("x".into()))),
-                statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(3))),
-                    Box::new(Expression::Num(Num::Integer(4)))
-                ))],
-                else_statements: vec![Statement::YieldingExpression(Expression::Addition(
-                    Box::new(Expression::Num(Num::Integer(42))),
-                    Box::new(Expression::Num(Num::Integer(1337)))
-                ))],
+                statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(3)),
+                        Expression::Num(Num::Integer(4))
+                    )
+                )))],
+                else_statements: vec![Statement::YieldingExpression(Expression::Binary(Box::new(
+                    BinaryExpression::Addition(
+                        Expression::Num(Num::Integer(42)),
+                        Expression::Num(Num::Integer(1337))
+                    )
+                )))],
             })
             .into()),
             result


### PR DESCRIPTION
## Description

This PR adds support for operator precedence during parsing. 

### Details

Precedence of binary operators now gets handled correctly. Binary expressions are "balanced" right after parsing, according to their respective precedence.

Closes #26 