### PR TITLE
chore(deps): add daily updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "crates/why_lib"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a new Dependabot configuration to enable daily update checks
for GitHub Actions workflows. This ensures that GitHub Actions
dependencies stay up to date and improves security and stability.
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#2g68AWLaR`](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/2g68AWLaR)

**chore(deps): add daily updates for GitHub Actions**


Add a new Dependabot configuration to enable daily update checks
for GitHub Actions workflows. This ensures that GitHub Actions
dependencies stay up to date and improves security and stability.

1 commit series (version 1)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 1/1 | [chore(deps): add daily updates for GitHub Actions](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/2g68AWLaR/commit/60e0ee63-cc92-4fe6-b3c2-04c30df6bf84) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/2g68AWLaR)_
<!-- GitButler Review Footer Boundary Bottom -->
