### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,4 +1,6 @@
 name: CI Checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/H1ghBre4k3r/pesca-lang/security/code-scanning/6](https://github.com/H1ghBre4k3r/pesca-lang/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions for the tasks performed in the workflow. Since none of the jobs in the workflow require write permissions, this minimal configuration is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
