### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,5 +1,7 @@
 name: CI Checks
 
+permissions:
+  contents: read
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/H1ghBre4k3r/pesca-lang/security/code-scanning/1](https://github.com/H1ghBre4k3r/pesca-lang/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary access to read repository contents. If any job requires additional permissions, they can be specified within that job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
