### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,5 +1,7 @@
 name: CI Checks
 
+permissions:
+  contents: read
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/H1ghBre4k3r/pesca-lang/security/code-scanning/2](https://github.com/H1ghBre4k3r/pesca-lang/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves building, testing, linting, and formatting code, it does not require write permissions. The minimal required permission is `contents: read`. We will add this permission at the root level of the workflow to apply it to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
