### PR TITLE
Make AST Serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "colored",
  "lex_derive",
  "regex",
+ "serde",
 ]
 
 [[package]]

--- a/crates/lex_derive/src/token.rs
+++ b/crates/lex_derive/src/token.rs
@@ -161,7 +161,7 @@ pub fn impl_token_macro(ast: syn::DeriveInput) -> TokenStream {
         .collect::<Punctuated<Variant, Comma>>();
 
     let gen = quote! {
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
         pub enum Terminal {
             #terminal_variants_tuples
         }

--- a/crates/why_lib/Cargo.toml
+++ b/crates/why_lib/Cargo.toml
@@ -12,3 +12,4 @@ anyhow = "1.0.98"
 colored = "3.0.0"
 lex_derive = { path = "../lex_derive/" }
 regex = "1.11.1"
+serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/why_lib/src/lexer/lexmap.rs
+++ b/crates/why_lib/src/lexer/lexmap.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::Terminal;
 
 /// Struct for storing terminal symbols with their respective "key".
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct LexMap {
     map: HashMap<&'static str, Terminal>,
 }

--- a/crates/why_lib/src/lexer/mod.rs
+++ b/crates/why_lib/src/lexer/mod.rs
@@ -4,7 +4,7 @@ pub use token::*;
 
 use std::{error::Error, fmt::Display};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LexError(String);
 
 pub type LexResult<T> = Result<T, LexError>;

--- a/crates/why_lib/src/lexer/token.rs
+++ b/crates/why_lib/src/lexer/token.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use lex_derive::{LooseEq, Token as ParseToken};
 use regex::{Match, Regex};
 
-#[derive(Default, Debug, Clone, Eq)]
+#[derive(Default, Debug, Clone, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Span {
     pub start: (usize, usize),
     pub end: (usize, usize),
@@ -87,7 +87,7 @@ impl PartialEq<Span> for Span {
     }
 }
 
-#[derive(Clone, ParseToken, LooseEq)]
+#[derive(Clone, ParseToken, LooseEq, serde::Serialize, serde::Deserialize)]
 pub enum Token {
     #[terminal("=")]
     Assign { position: Span },

--- a/crates/why_lib/src/lexer/token.rs
+++ b/crates/why_lib/src/lexer/token.rs
@@ -16,7 +16,7 @@ impl Span {
         let line = start.0;
         let lines = source.lines().collect::<Vec<_>>();
         let prev_line = if line > 0 { lines[line - 1] } else { "" };
-        let line_str = lines[line];
+        let line_str = if lines.len() > line { lines[line] } else { "" };
 
         // margin _before_ left border
         let left_margin = format!("{}", end.0).len();
@@ -46,7 +46,9 @@ impl Span {
         let line_str = format!("{left}{right}");
 
         // padding between border and squiggles
-        let left_padding_fill = vec![' '; end.1 - 1].iter().collect::<String>();
+        let left_padding_fill = vec![' '; if end.1 > 0 { end.1 - 1 } else { 0 }]
+            .iter()
+            .collect::<String>();
 
         // the error with the first line
         let mut error_string = format!(

--- a/crates/why_lib/src/parser/ast/expression/array.rs
+++ b/crates/why_lib/src/parser/ast/expression/array.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{Expression, Num};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Array<T> {
     Literal {
         values: Vec<Expression<T>>,

--- a/crates/why_lib/src/parser/ast/expression/binary.rs
+++ b/crates/why_lib/src/parser/ast/expression/binary.rs
@@ -2,7 +2,7 @@ use crate::lexer::Span;
 
 use super::Expression;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BinaryOperator {
     Add,
     Substract,
@@ -15,7 +15,7 @@ pub enum BinaryOperator {
     LessOrEqual,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct BinaryExpression<T> {
     pub left: Expression<T>,
     pub right: Expression<T>,

--- a/crates/why_lib/src/parser/ast/expression/block.rs
+++ b/crates/why_lib/src/parser/ast/expression/block.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Block<T> {
     pub statements: Vec<Statement<T>>,
     pub info: T,

--- a/crates/why_lib/src/parser/ast/expression/character.rs
+++ b/crates/why_lib/src/parser/ast/expression/character.rs
@@ -2,7 +2,7 @@ use crate::lexer::{Span, Token};
 use crate::parser::ast::AstNode;
 use crate::parser::{FromTokens, ParseError, ParseState};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Character<T> {
     pub character: char,
     pub position: Span,

--- a/crates/why_lib/src/parser/ast/expression/function.rs
+++ b/crates/why_lib/src/parser/ast/expression/function.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::Id;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Function<T> {
     pub id: Id<T>,
     pub parameters: Vec<FunctionParameter<T>>,
@@ -75,7 +75,7 @@ impl From<Function<()>> for AstNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FunctionParameter<T> {
     pub name: Id<T>,
     pub type_name: TypeName,

--- a/crates/why_lib/src/parser/ast/expression/id.rs
+++ b/crates/why_lib/src/parser/ast/expression/id.rs
@@ -3,7 +3,7 @@ use crate::{
     parser::{ast::AstNode, FromTokens, ParseError, ParseState},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Id<T> {
     pub name: String,
     pub info: T,

--- a/crates/why_lib/src/parser/ast/expression/if_expression.rs
+++ b/crates/why_lib/src/parser/ast/expression/if_expression.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::Expression;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct If<T> {
     pub condition: Box<Expression<T>>,
     // TODO: This should/could just be a block

--- a/crates/why_lib/src/parser/ast/expression/lambda.rs
+++ b/crates/why_lib/src/parser/ast/expression/lambda.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{Expression, Id};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Lambda<T> {
     pub parameters: Vec<LambdaParameter<T>>,
     pub expression: Box<Expression<T>>,
@@ -56,7 +56,7 @@ impl From<Lambda<()>> for AstNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LambdaParameter<T> {
     pub name: Id<T>,
     pub info: T,

--- a/crates/why_lib/src/parser/ast/expression/mod.rs
+++ b/crates/why_lib/src/parser/ast/expression/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 
 use super::AstNode;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Expression<T> {
     Id(Id<T>),
     Num(Num<T>),

--- a/crates/why_lib/src/parser/ast/expression/num.rs
+++ b/crates/why_lib/src/parser/ast/expression/num.rs
@@ -3,7 +3,7 @@ use crate::{
     parser::{ast::AstNode, FromTokens, ParseError, ParseState},
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Num<T> {
     Integer(u64, T, Span),
     FloatingPoint(f64, T, Span),

--- a/crates/why_lib/src/parser/ast/expression/postfix.rs
+++ b/crates/why_lib/src/parser/ast/expression/postfix.rs
@@ -2,7 +2,7 @@ use crate::lexer::Span;
 
 use super::{Expression, Id};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Postfix<T> {
     Call {
         expr: Box<Expression<T>>,

--- a/crates/why_lib/src/parser/ast/expression/prefix.rs
+++ b/crates/why_lib/src/parser/ast/expression/prefix.rs
@@ -2,7 +2,7 @@ use crate::lexer::Span;
 
 use super::Expression;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Prefix<T> {
     Negation {
         expr: Box<Expression<T>>,

--- a/crates/why_lib/src/parser/ast/expression/string.rs
+++ b/crates/why_lib/src/parser/ast/expression/string.rs
@@ -2,7 +2,7 @@ use crate::lexer::{Span, Token};
 use crate::parser::ast::AstNode;
 use crate::parser::{FromTokens, ParseError, ParseState};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AstString<T> {
     pub value: String,
     pub info: T,

--- a/crates/why_lib/src/parser/ast/expression/struct_initialisation.rs
+++ b/crates/why_lib/src/parser/ast/expression/struct_initialisation.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{Expression, Id};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StructInitialisation<T> {
     pub id: Id<T>,
     pub fields: Vec<StructFieldInitialisation<T>>,
@@ -50,7 +50,7 @@ impl From<StructInitialisation<()>> for AstNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StructFieldInitialisation<T> {
     pub name: Id<T>,
     pub value: Expression<T>,

--- a/crates/why_lib/src/parser/ast/mod.rs
+++ b/crates/why_lib/src/parser/ast/mod.rs
@@ -6,7 +6,7 @@ pub use self::expression::*;
 pub use self::statement::*;
 pub use self::type_name::*;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum AstNode {
     Expression(Expression<()>),
     Id(Id<()>),

--- a/crates/why_lib/src/parser/ast/statement/assignment.rs
+++ b/crates/why_lib/src/parser/ast/statement/assignment.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Assignment<T> {
     pub lvalue: LValue<T>,
     pub rvalue: Expression<T>,
@@ -49,7 +49,7 @@ impl From<Assignment<()>> for AstNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum LValue<T> {
     Id(Id<T>),
     Postfix(Postfix<T>),

--- a/crates/why_lib/src/parser/ast/statement/constant.rs
+++ b/crates/why_lib/src/parser/ast/statement/constant.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Constant<T> {
     pub id: Id<T>,
     pub type_name: TypeName,

--- a/crates/why_lib/src/parser/ast/statement/declaration.rs
+++ b/crates/why_lib/src/parser/ast/statement/declaration.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Declaration<T> {
     pub name: Id<T>,
     pub type_name: TypeName,

--- a/crates/why_lib/src/parser/ast/statement/initialisation.rs
+++ b/crates/why_lib/src/parser/ast/statement/initialisation.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Initialisation<T> {
     pub id: Id<T>,
     pub mutable: bool,

--- a/crates/why_lib/src/parser/ast/statement/instance.rs
+++ b/crates/why_lib/src/parser/ast/statement/instance.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::MethodDeclaration;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Instance<T> {
     pub name: TypeName,
     pub functions: Vec<Function<T>>,

--- a/crates/why_lib/src/parser/ast/statement/method_declaration.rs
+++ b/crates/why_lib/src/parser/ast/statement/method_declaration.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MethodDeclaration<T> {
     pub id: Id<T>,
     pub parameter_types: Vec<TypeName>,

--- a/crates/why_lib/src/parser/ast/statement/mod.rs
+++ b/crates/why_lib/src/parser/ast/statement/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{AstNode, Expression, Function, If};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Statement<T> {
     Function(Function<T>),
     If(If<T>),
@@ -42,7 +42,7 @@ pub enum Statement<T> {
 }
 
 /// Everything that is allowed at toplevel
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TopLevelStatement<T> {
     Comment(String),
     Function(Function<T>),

--- a/crates/why_lib/src/parser/ast/statement/struct_declaration.rs
+++ b/crates/why_lib/src/parser/ast/statement/struct_declaration.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StructDeclaration<T> {
     pub id: Id<T>,
     pub fields: Vec<StructFieldDeclaration<T>>,
@@ -52,7 +52,7 @@ impl From<StructDeclaration<()>> for AstNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StructFieldDeclaration<T> {
     pub name: Id<T>,
     pub type_name: TypeName,

--- a/crates/why_lib/src/parser/ast/statement/while_loop.rs
+++ b/crates/why_lib/src/parser/ast/statement/while_loop.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WhileLoop<T> {
     pub condition: Expression<T>,
     pub block: Block<T>,

--- a/crates/why_lib/src/parser/ast/type_name.rs
+++ b/crates/why_lib/src/parser/ast/type_name.rs
@@ -10,7 +10,7 @@ use crate::parser::ParseState;
 
 use super::AstNode;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TypeName {
     Literal(String, Span),
     Fn {

--- a/crates/why_lib/src/parser/mod.rs
+++ b/crates/why_lib/src/parser/mod.rs
@@ -10,7 +10,7 @@ use crate::lexer::{GetPosition, Span, Token};
 
 use self::ast::{AstNode, TopLevelStatement};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ParseError {
     pub message: String,
     pub position: Option<Span>,

--- a/crates/why_lib/src/parser/parse_state.rs
+++ b/crates/why_lib/src/parser/parse_state.rs
@@ -1,7 +1,7 @@
 use crate::parser::ParseError;
 
 /// Struct for iterating over a vector of tokens.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ParseState<T> {
     tokens: Vec<T>,
     index: usize,

--- a/crates/why_lib/src/typechecker/error.rs
+++ b/crates/why_lib/src/typechecker/error.rs
@@ -15,6 +15,8 @@ pub enum TypeCheckError {
     RedefinedFunction(RedefinedFunction, Span),
     RedefinedMethod(RedefinedMethod, Span),
     ImmutableReassign(ImmutableReassign, Span),
+    MissingMainFunction(MissingMainFunction),
+    InvalidMainSignature(InvalidMainSignature, Span),
 }
 
 impl Display for TypeCheckError {
@@ -35,6 +37,8 @@ impl TypeCheckError {
             TypeCheckError::RedefinedFunction(_, span) => span.clone(),
             TypeCheckError::RedefinedMethod(_, span) => span.clone(),
             TypeCheckError::ImmutableReassign(_, span) => span.clone(),
+            TypeCheckError::MissingMainFunction(_) => Span::default(),
+            TypeCheckError::InvalidMainSignature(_, span) => span.clone(),
         }
     }
 
@@ -49,6 +53,8 @@ impl TypeCheckError {
             TypeCheckError::RedefinedFunction(e, _) => Box::new(e.clone()),
             TypeCheckError::RedefinedMethod(e, _) => Box::new(e.clone()),
             TypeCheckError::ImmutableReassign(e, _) => Box::new(e.clone()),
+            TypeCheckError::MissingMainFunction(e) => Box::new(e.clone()),
+            TypeCheckError::InvalidMainSignature(e, _) => Box::new(e.clone()),
         }
     }
 }
@@ -192,3 +198,25 @@ impl Display for ImmutableReassign {
 }
 
 impl Error for ImmutableReassign {}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MissingMainFunction;
+
+impl Display for MissingMainFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Missing main function!")
+    }
+}
+
+impl Error for MissingMainFunction {}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InvalidMainSignature;
+
+impl Display for InvalidMainSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("The main function does not have a valid signature. It must not accept any arguments and must return either void or an integer!")
+    }
+}
+
+impl Error for InvalidMainSignature {}

--- a/crates/why_lib/src/typechecker/error.rs
+++ b/crates/why_lib/src/typechecker/error.rs
@@ -4,7 +4,7 @@ use crate::{lexer::Span, parser::ast::TypeName};
 
 use super::types::Type;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TypeCheckError {
     TypeMismatch(TypeMismatch, Span),
     UndefinedVariable(UndefinedVariable, Span),
@@ -55,7 +55,7 @@ impl TypeCheckError {
 
 impl Error for TypeCheckError {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TypeMismatch {
     pub expected: Type,
     pub actual: Type,
@@ -72,7 +72,7 @@ impl Display for TypeMismatch {
 
 impl Error for TypeMismatch {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct UndefinedVariable {
     pub variable_name: String,
 }
@@ -88,7 +88,7 @@ impl Display for UndefinedVariable {
 
 impl Error for UndefinedVariable {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct UndefinedType {
     pub type_name: TypeName,
 }
@@ -101,7 +101,7 @@ impl Display for UndefinedType {
 
 impl Error for UndefinedType {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MissingInitialisationType;
 
 impl Display for MissingInitialisationType {
@@ -112,7 +112,7 @@ impl Display for MissingInitialisationType {
 
 impl Error for MissingInitialisationType {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InvalidConstantType {
     pub constant_name: String,
 }
@@ -128,7 +128,7 @@ impl Display for InvalidConstantType {
 
 impl Error for InvalidConstantType {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RedefinedConstant {
     pub constant_name: String,
 }
@@ -144,7 +144,7 @@ impl Display for RedefinedConstant {
 
 impl Error for RedefinedConstant {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RedefinedFunction {
     pub function_name: String,
 }
@@ -160,7 +160,7 @@ impl Display for RedefinedFunction {
 
 impl Error for RedefinedFunction {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RedefinedMethod {
     pub type_id: Type,
     pub function_name: String,
@@ -177,7 +177,7 @@ impl Display for RedefinedMethod {
 
 impl Error for RedefinedMethod {}
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ImmutableReassign {
     pub variable_name: String,
 }

--- a/crates/why_lib/src/typechecker/mod.rs
+++ b/crates/why_lib/src/typechecker/mod.rs
@@ -25,9 +25,10 @@ impl TypeInformation {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct ValidatedTypeInformation {
     pub type_id: Type,
+    #[serde(skip)]
     pub context: Context,
 }
 
@@ -44,7 +45,7 @@ impl TypeInformation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TypeValidationError(Span);
 
 impl Display for TypeValidationError {

--- a/crates/why_lib/src/typechecker/mod.rs
+++ b/crates/why_lib/src/typechecker/mod.rs
@@ -159,16 +159,13 @@ impl TypeChecker {
 
         let main = { main.borrow().clone().unwrap() };
 
-        println!("{main:#?}");
-
         match main {
             Type::Function {
                 params,
                 return_value,
             } => {
                 if !params.is_empty()
-                    || *return_value != Type::Void
-                    || *return_value != Type::Integer
+                    && (*return_value != Type::Void || *return_value != Type::Integer)
                 {
                     // TODO: we need to return the correct span of the main function for better
                     // error display

--- a/crates/why_lib/src/typechecker/mod.rs
+++ b/crates/why_lib/src/typechecker/mod.rs
@@ -48,13 +48,21 @@ impl TypeInformation {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TypeValidationError(Span);
 
+impl TypeValidationError {
+    const MESSAGE: &'static str = "Type must be known at compile time!";
+
+    pub fn span(&self) -> Span {
+        self.0.clone()
+    }
+
+    pub fn err(&self) -> String {
+        Self::MESSAGE.to_string()
+    }
+}
+
 impl Display for TypeValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(
-            self.0
-                .to_string("Type must be known at compile time!")
-                .as_str(),
-        )
+        f.write_str(self.0.to_string(Self::MESSAGE).as_str())
     }
 }
 

--- a/crates/why_lib/src/typechecker/scope.rs
+++ b/crates/why_lib/src/typechecker/scope.rs
@@ -11,6 +11,8 @@ struct StoredVariable {
     mutable: bool,
 }
 
+// TODO: this should probably store the location (i.e, span) for all variables, constants and types
+// as well
 #[derive(Clone, Default)]
 /// A frame within a stack, holding information about all variables, types, and constants.
 pub struct Frame {

--- a/crates/why_lib/src/typechecker/scope.rs
+++ b/crates/why_lib/src/typechecker/scope.rs
@@ -62,7 +62,7 @@ impl Default for Scope {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TypeAddError {
     pub name: String,
     pub type_id: Type,
@@ -79,7 +79,7 @@ impl Display for TypeAddError {
 
 impl std::error::Error for TypeAddError {}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VariableAddError {
     pub name: String,
 }
@@ -95,7 +95,7 @@ impl Display for VariableAddError {
 
 impl std::error::Error for VariableAddError {}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MethodAddError {
     pub name: String,
 }

--- a/crates/why_lib/src/typechecker/types.rs
+++ b/crates/why_lib/src/typechecker/types.rs
@@ -7,7 +7,7 @@ use super::{
     error::{TypeCheckError, UndefinedType},
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Type {
     Integer,
     FloatingPoint,
@@ -78,7 +78,7 @@ impl std::fmt::Debug for Type {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TypeFromTypeNameError {
     source: TypeName,
 }

--- a/examples/main.why
+++ b/examples/main.why
@@ -37,7 +37,7 @@ instance str {
     declare len(): i64;
 }
 
-fn main(): void {
+fn main(): i64 {
     let a = add(42, 1337);
 
     let mut arr = [42, 1337];
@@ -90,6 +90,8 @@ fn main(): void {
     let value_of_x = b.t.get_x();
 
     let id = b.t.get_id();
+
+    return 0;
 }
 
 fn asd(): TestStruct {

--- a/src/bin/yls.rs
+++ b/src/bin/yls.rs
@@ -80,11 +80,20 @@ impl Backend {
             }
         };
 
-        let _ = match typechecker::TypeChecker::new(parsed).check() {
+        let checked = match typechecker::TypeChecker::new(parsed).check() {
             Ok(checked) => checked,
             Err(e) => {
                 let position = e.span();
                 let message = e.err().to_string();
+                return Some((message, position));
+            }
+        };
+
+        let _ = match typechecker::TypeChecker::validate(checked) {
+            Ok(validated) => validated,
+            Err(e) => {
+                let position = e.span();
+                let message = e.err();
                 return Some((message, position));
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,12 @@ pub struct Cli {
     #[arg(short = 'p', long)]
     pub print_parsed: bool,
 
+    #[arg(short = 'c', long)]
+    pub print_checked: bool,
+
+    #[arg(short = 'v', long)]
+    pub print_validated: bool,
+
     #[arg(short, long, default_value = "a.out")]
     pub output: Option<std::path::PathBuf>,
 }
@@ -58,6 +64,10 @@ pub fn compile_file(args: Cli) -> anyhow::Result<()> {
         }
     };
 
+    if args.print_checked {
+        println!("{checked:#?}");
+    }
+
     let validated = match TypeChecker::validate(checked) {
         Ok(validated) => validated,
         Err(e) => {
@@ -66,10 +76,9 @@ pub fn compile_file(args: Cli) -> anyhow::Result<()> {
         }
     };
 
-    // println!("{validated:#?}");
-
-    let res = serde_json::to_string(&validated)?;
-    println!("{res}");
+    if args.print_validated {
+        println!("{validated:#?}");
+    }
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::{fs, process};
 use clap::{Parser, command};
 use why_lib::{lexer::Lexer, parser::parse, typechecker::TypeChecker};
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, serde::Serialize, serde::Deserialize)]
 #[command(author, version, about)]
 #[command(propagate_version = true)]
 pub struct Cli {
@@ -66,7 +66,10 @@ pub fn compile_file(args: Cli) -> anyhow::Result<()> {
         }
     };
 
-    println!("{validated:#?}");
+    // println!("{validated:#?}");
+
+    let res = serde_json::to_string(&validated)?;
+    println!("{res}");
 
     Ok(())
 }

--- a/test.json
+++ b/test.json
@@ -1,0 +1,3738 @@
+[
+  {
+    "Constant": {
+      "id": {
+        "name": "PI",
+        "info": { "type_id": "FloatingPoint" },
+        "position": {
+          "start": [0, 6],
+          "end": [0, 8],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "type_name": {
+        "Literal": [
+          "f64",
+          {
+            "start": [0, 10],
+            "end": [0, 13],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "value": {
+        "Num": {
+          "FloatingPoint": [
+            3.1415,
+            { "type_id": "FloatingPoint" },
+            {
+              "start": [0, 16],
+              "end": [0, 22],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          ]
+        }
+      },
+      "info": { "type_id": "Void" },
+      "position": {
+        "start": [0, 0],
+        "end": [0, 5],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Function": {
+      "id": {
+        "name": "add",
+        "info": {
+          "type_id": {
+            "Function": {
+              "params": ["Integer", "Integer"],
+              "return_value": "Integer"
+            }
+          }
+        },
+        "position": {
+          "start": [2, 3],
+          "end": [2, 6],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "parameters": [
+        {
+          "name": {
+            "name": "x",
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [2, 7],
+              "end": [2, 8],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Literal": [
+              "i64",
+              {
+                "start": [2, 10],
+                "end": [2, 13],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Integer" },
+          "position": {
+            "start": [2, 7],
+            "end": [2, 8],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        },
+        {
+          "name": {
+            "name": "y",
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [2, 15],
+              "end": [2, 16],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Literal": [
+              "i64",
+              {
+                "start": [2, 18],
+                "end": [2, 21],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Integer" },
+          "position": {
+            "start": [2, 15],
+            "end": [2, 16],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "return_type": {
+        "Literal": [
+          "i64",
+          {
+            "start": [2, 24],
+            "end": [2, 27],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "statements": [
+        {
+          "YieldingExpression": {
+            "Binary": {
+              "left": {
+                "Id": {
+                  "name": "x",
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [3, 4],
+                    "end": [3, 5],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              },
+              "right": {
+                "Id": {
+                  "name": "y",
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [3, 8],
+                    "end": [3, 9],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              },
+              "operator": "Add",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [3, 6],
+                "end": [3, 7],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          }
+        }
+      ],
+      "info": {
+        "type_id": {
+          "Function": {
+            "params": ["Integer", "Integer"],
+            "return_value": "Integer"
+          }
+        }
+      },
+      "position": {
+        "start": [2, 0],
+        "end": [2, 2],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Function": {
+      "id": {
+        "name": "explicit_return_add",
+        "info": {
+          "type_id": {
+            "Function": {
+              "params": ["Integer", "Integer"],
+              "return_value": "Integer"
+            }
+          }
+        },
+        "position": {
+          "start": [6, 3],
+          "end": [6, 22],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "parameters": [
+        {
+          "name": {
+            "name": "x",
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [6, 23],
+              "end": [6, 24],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Literal": [
+              "i64",
+              {
+                "start": [6, 26],
+                "end": [6, 29],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Integer" },
+          "position": {
+            "start": [6, 23],
+            "end": [6, 24],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        },
+        {
+          "name": {
+            "name": "y",
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [6, 31],
+              "end": [6, 32],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Literal": [
+              "i64",
+              {
+                "start": [6, 34],
+                "end": [6, 37],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Integer" },
+          "position": {
+            "start": [6, 31],
+            "end": [6, 32],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "return_type": {
+        "Literal": [
+          "i64",
+          {
+            "start": [6, 40],
+            "end": [6, 43],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "statements": [
+        {
+          "Return": {
+            "Binary": {
+              "left": {
+                "Id": {
+                  "name": "x",
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [7, 11],
+                    "end": [7, 12],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              },
+              "right": {
+                "Id": {
+                  "name": "y",
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [7, 15],
+                    "end": [7, 16],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              },
+              "operator": "Add",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [7, 13],
+                "end": [7, 14],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          }
+        }
+      ],
+      "info": {
+        "type_id": {
+          "Function": {
+            "params": ["Integer", "Integer"],
+            "return_value": "Integer"
+          }
+        }
+      },
+      "position": {
+        "start": [6, 0],
+        "end": [6, 2],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "StructDeclaration": {
+      "id": {
+        "name": "TestStruct",
+        "info": { "type_id": "Void" },
+        "position": {
+          "start": [10, 7],
+          "end": [10, 17],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "fields": [
+        {
+          "name": {
+            "name": "x",
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [11, 4],
+              "end": [11, 5],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Literal": [
+              "i64",
+              {
+                "start": [11, 7],
+                "end": [11, 10],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Integer" },
+          "position": {
+            "start": [11, 4],
+            "end": [11, 5],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        },
+        {
+          "name": {
+            "name": "bar",
+            "info": {
+              "type_id": {
+                "Function": {
+                  "params": ["Integer", "Integer"],
+                  "return_value": "Integer"
+                }
+              }
+            },
+            "position": {
+              "start": [12, 4],
+              "end": [12, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Fn": {
+              "params": [
+                {
+                  "Literal": [
+                    "i64",
+                    {
+                      "start": [12, 10],
+                      "end": [12, 13],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  ]
+                },
+                {
+                  "Literal": [
+                    "i64",
+                    {
+                      "start": [12, 15],
+                      "end": [12, 18],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  ]
+                }
+              ],
+              "return_type": {
+                "Literal": [
+                  "i64",
+                  {
+                    "start": [12, 23],
+                    "end": [12, 26],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                ]
+              },
+              "position": {
+                "start": [12, 9],
+                "end": [12, 26],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          },
+          "info": {
+            "type_id": {
+              "Function": {
+                "params": ["Integer", "Integer"],
+                "return_value": "Integer"
+              }
+            }
+          },
+          "position": {
+            "start": [12, 4],
+            "end": [12, 7],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "info": { "type_id": "Void" },
+      "position": {
+        "start": [10, 0],
+        "end": [10, 6],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "StructDeclaration": {
+      "id": {
+        "name": "Bar",
+        "info": { "type_id": "Void" },
+        "position": {
+          "start": [15, 7],
+          "end": [15, 10],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "fields": [
+        {
+          "name": {
+            "name": "t",
+            "info": {
+              "type_id": {
+                "Struct": [
+                  "TestStruct",
+                  [
+                    ["x", "Integer"],
+                    [
+                      "bar",
+                      {
+                        "Function": {
+                          "params": ["Integer", "Integer"],
+                          "return_value": "Integer"
+                        }
+                      }
+                    ]
+                  ]
+                ]
+              }
+            },
+            "position": {
+              "start": [16, 4],
+              "end": [16, 5],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Literal": [
+              "TestStruct",
+              {
+                "start": [16, 7],
+                "end": [16, 17],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": {
+            "type_id": {
+              "Struct": [
+                "TestStruct",
+                [
+                  ["x", "Integer"],
+                  [
+                    "bar",
+                    {
+                      "Function": {
+                        "params": ["Integer", "Integer"],
+                        "return_value": "Integer"
+                      }
+                    }
+                  ]
+                ]
+              ]
+            }
+          },
+          "position": {
+            "start": [16, 4],
+            "end": [16, 5],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "info": { "type_id": "Void" },
+      "position": {
+        "start": [15, 0],
+        "end": [15, 6],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Instance": {
+      "name": {
+        "Literal": [
+          "TestStruct",
+          {
+            "start": [19, 9],
+            "end": [19, 19],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "functions": [
+        {
+          "id": {
+            "name": "get_x",
+            "info": {
+              "type_id": {
+                "Function": { "params": [], "return_value": "Integer" }
+              }
+            },
+            "position": {
+              "start": [22, 7],
+              "end": [22, 12],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "parameters": [],
+          "return_type": {
+            "Literal": [
+              "i64",
+              {
+                "start": [22, 16],
+                "end": [22, 19],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "statements": [
+            {
+              "Return": {
+                "Postfix": {
+                  "PropertyAccess": {
+                    "expr": {
+                      "Id": {
+                        "name": "this",
+                        "info": {
+                          "type_id": {
+                            "Struct": [
+                              "TestStruct",
+                              [
+                                ["x", "Integer"],
+                                [
+                                  "bar",
+                                  {
+                                    "Function": {
+                                      "params": ["Integer", "Integer"],
+                                      "return_value": "Integer"
+                                    }
+                                  }
+                                ]
+                              ]
+                            ]
+                          }
+                        },
+                        "position": {
+                          "start": [23, 15],
+                          "end": [23, 19],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    },
+                    "property": {
+                      "name": "x",
+                      "info": { "type_id": "Integer" },
+                      "position": {
+                        "start": [23, 20],
+                        "end": [23, 21],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    },
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [23, 19],
+                      "end": [23, 20],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "info": {
+            "type_id": {
+              "Function": { "params": [], "return_value": "Integer" }
+            }
+          },
+          "position": {
+            "start": [22, 4],
+            "end": [22, 6],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        },
+        {
+          "id": {
+            "name": "set_x",
+            "info": {
+              "type_id": {
+                "Function": { "params": ["Integer"], "return_value": "Void" }
+              }
+            },
+            "position": {
+              "start": [26, 7],
+              "end": [26, 12],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "parameters": [
+            {
+              "name": {
+                "name": "x",
+                "info": { "type_id": "Integer" },
+                "position": {
+                  "start": [26, 13],
+                  "end": [26, 14],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              },
+              "type_name": {
+                "Literal": [
+                  "i64",
+                  {
+                    "start": [26, 16],
+                    "end": [26, 19],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                ]
+              },
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [26, 13],
+                "end": [26, 14],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          ],
+          "return_type": {
+            "Literal": [
+              "void",
+              {
+                "start": [26, 22],
+                "end": [26, 26],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "statements": [
+            {
+              "Assignment": {
+                "lvalue": {
+                  "Postfix": {
+                    "PropertyAccess": {
+                      "expr": {
+                        "Id": {
+                          "name": "this",
+                          "info": {
+                            "type_id": {
+                              "Struct": [
+                                "TestStruct",
+                                [
+                                  ["x", "Integer"],
+                                  [
+                                    "bar",
+                                    {
+                                      "Function": {
+                                        "params": ["Integer", "Integer"],
+                                        "return_value": "Integer"
+                                      }
+                                    }
+                                  ]
+                                ]
+                              ]
+                            }
+                          },
+                          "position": {
+                            "start": [27, 8],
+                            "end": [27, 12],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        }
+                      },
+                      "property": {
+                        "name": "x",
+                        "info": { "type_id": "Integer" },
+                        "position": {
+                          "start": [27, 13],
+                          "end": [27, 14],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      },
+                      "info": { "type_id": "Integer" },
+                      "position": {
+                        "start": [27, 12],
+                        "end": [27, 13],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  }
+                },
+                "rvalue": {
+                  "Id": {
+                    "name": "x",
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [27, 17],
+                      "end": [27, 18],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                },
+                "info": { "type_id": "Integer" },
+                "position": {
+                  "start": [27, 8],
+                  "end": [27, 18],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            }
+          ],
+          "info": {
+            "type_id": {
+              "Function": { "params": ["Integer"], "return_value": "Void" }
+            }
+          },
+          "position": {
+            "start": [26, 4],
+            "end": [26, 6],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "declarations": [
+        {
+          "id": {
+            "name": "get_id",
+            "info": {
+              "type_id": {
+                "Function": { "params": [], "return_value": "Integer" }
+              }
+            },
+            "position": {
+              "start": [20, 12],
+              "end": [20, 18],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "parameter_types": [],
+          "return_type": {
+            "Literal": [
+              "i64",
+              {
+                "start": [20, 22],
+                "end": [20, 25],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Void" },
+          "position": {
+            "start": [20, 4],
+            "end": [20, 26],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "info": { "type_id": "Void" },
+      "position": {
+        "start": [19, 0],
+        "end": [29, 1],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Function": {
+      "id": {
+        "name": "takes_function",
+        "info": {
+          "type_id": {
+            "Function": {
+              "params": [
+                {
+                  "Function": {
+                    "params": ["Integer", "Integer"],
+                    "return_value": "Integer"
+                  }
+                }
+              ],
+              "return_value": "Integer"
+            }
+          }
+        },
+        "position": {
+          "start": [31, 3],
+          "end": [31, 17],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "parameters": [
+        {
+          "name": {
+            "name": "func",
+            "info": {
+              "type_id": {
+                "Function": {
+                  "params": ["Integer", "Integer"],
+                  "return_value": "Integer"
+                }
+              }
+            },
+            "position": {
+              "start": [31, 18],
+              "end": [31, 22],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "type_name": {
+            "Fn": {
+              "params": [
+                {
+                  "Literal": [
+                    "i64",
+                    {
+                      "start": [31, 25],
+                      "end": [31, 28],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  ]
+                },
+                {
+                  "Literal": [
+                    "i64",
+                    {
+                      "start": [31, 30],
+                      "end": [31, 33],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  ]
+                }
+              ],
+              "return_type": {
+                "Literal": [
+                  "i64",
+                  {
+                    "start": [31, 38],
+                    "end": [31, 41],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                ]
+              },
+              "position": {
+                "start": [31, 24],
+                "end": [31, 41],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          },
+          "info": {
+            "type_id": {
+              "Function": {
+                "params": ["Integer", "Integer"],
+                "return_value": "Integer"
+              }
+            }
+          },
+          "position": {
+            "start": [31, 18],
+            "end": [31, 22],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "return_type": {
+        "Literal": [
+          "i64",
+          {
+            "start": [31, 44],
+            "end": [31, 47],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "statements": [
+        {
+          "YieldingExpression": {
+            "Postfix": {
+              "Call": {
+                "expr": {
+                  "Id": {
+                    "name": "func",
+                    "info": {
+                      "type_id": {
+                        "Function": {
+                          "params": ["Integer", "Integer"],
+                          "return_value": "Integer"
+                        }
+                      }
+                    },
+                    "position": {
+                      "start": [32, 4],
+                      "end": [32, 8],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                },
+                "args": [
+                  {
+                    "Num": {
+                      "Integer": [
+                        42,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [32, 9],
+                          "end": [32, 11],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Num": {
+                      "Integer": [
+                        69,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [32, 13],
+                          "end": [32, 15],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "info": { "type_id": "Integer" },
+                "position": {
+                  "start": [32, 8],
+                  "end": [32, 9],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "info": {
+        "type_id": {
+          "Function": {
+            "params": [
+              {
+                "Function": {
+                  "params": ["Integer", "Integer"],
+                  "return_value": "Integer"
+                }
+              }
+            ],
+            "return_value": "Integer"
+          }
+        }
+      },
+      "position": {
+        "start": [31, 0],
+        "end": [31, 2],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Instance": {
+      "name": {
+        "Literal": [
+          "str",
+          {
+            "start": [35, 9],
+            "end": [35, 12],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "functions": [],
+      "declarations": [
+        {
+          "id": {
+            "name": "len",
+            "info": {
+              "type_id": {
+                "Function": { "params": [], "return_value": "Integer" }
+              }
+            },
+            "position": {
+              "start": [36, 12],
+              "end": [36, 15],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          },
+          "parameter_types": [],
+          "return_type": {
+            "Literal": [
+              "i64",
+              {
+                "start": [36, 19],
+                "end": [36, 22],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "info": { "type_id": "Void" },
+          "position": {
+            "start": [36, 4],
+            "end": [36, 23],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      ],
+      "info": { "type_id": "Void" },
+      "position": {
+        "start": [35, 0],
+        "end": [37, 1],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Function": {
+      "id": {
+        "name": "main",
+        "info": {
+          "type_id": { "Function": { "params": [], "return_value": "Void" } }
+        },
+        "position": {
+          "start": [39, 3],
+          "end": [39, 7],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "parameters": [],
+      "return_type": {
+        "Literal": [
+          "void",
+          {
+            "start": [39, 11],
+            "end": [39, 15],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "statements": [
+        {
+          "Initialization": {
+            "id": {
+              "name": "a",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [40, 8],
+                "end": [40, 9],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Postfix": {
+                "Call": {
+                  "expr": {
+                    "Id": {
+                      "name": "add",
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [40, 12],
+                        "end": [40, 15],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  },
+                  "args": [
+                    {
+                      "Num": {
+                        "Integer": [
+                          42,
+                          { "type_id": "Integer" },
+                          {
+                            "start": [40, 16],
+                            "end": [40, 18],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "Num": {
+                        "Integer": [
+                          1337,
+                          { "type_id": "Integer" },
+                          {
+                            "start": [40, 20],
+                            "end": [40, 24],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [40, 15],
+                    "end": [40, 16],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [40, 4],
+              "end": [40, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "arr",
+              "info": { "type_id": { "Array": "Integer" } },
+              "position": {
+                "start": [42, 12],
+                "end": [42, 15],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": true,
+            "type_name": null,
+            "value": {
+              "Array": {
+                "Literal": {
+                  "values": [
+                    {
+                      "Num": {
+                        "Integer": [
+                          42,
+                          { "type_id": "Integer" },
+                          {
+                            "start": [42, 19],
+                            "end": [42, 21],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "Num": {
+                        "Integer": [
+                          1337,
+                          { "type_id": "Integer" },
+                          {
+                            "start": [42, 23],
+                            "end": [42, 27],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "info": { "type_id": { "Array": "Integer" } },
+                  "position": {
+                    "start": [42, 18],
+                    "end": [42, 19],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [42, 4],
+              "end": [42, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "arr2",
+              "info": { "type_id": { "Array": "Integer" } },
+              "position": {
+                "start": [44, 8],
+                "end": [44, 12],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Array": {
+                "Default": {
+                  "initial_value": {
+                    "Num": {
+                      "Integer": [
+                        1337,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [44, 16],
+                          "end": [44, 20],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  },
+                  "length": {
+                    "Integer": [
+                      5,
+                      { "type_id": "Integer" },
+                      {
+                        "start": [44, 22],
+                        "end": [44, 23],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    ]
+                  },
+                  "info": { "type_id": { "Array": "Integer" } },
+                  "position": {
+                    "start": [44, 15],
+                    "end": [44, 16],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [44, 4],
+              "end": [44, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "b",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [46, 8],
+                "end": [46, 9],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Postfix": {
+                "Call": {
+                  "expr": {
+                    "Id": {
+                      "name": "explicit_return_add",
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [46, 12],
+                        "end": [46, 31],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  },
+                  "args": [
+                    {
+                      "Postfix": {
+                        "Index": {
+                          "expr": {
+                            "Id": {
+                              "name": "arr",
+                              "info": { "type_id": { "Array": "Integer" } },
+                              "position": {
+                                "start": [46, 32],
+                                "end": [46, 35],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            }
+                          },
+                          "index": {
+                            "Num": {
+                              "Integer": [
+                                0,
+                                { "type_id": "Integer" },
+                                {
+                                  "start": [46, 36],
+                                  "end": [46, 37],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              ]
+                            }
+                          },
+                          "info": { "type_id": "Integer" },
+                          "position": {
+                            "start": [46, 35],
+                            "end": [46, 36],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "Postfix": {
+                        "Index": {
+                          "expr": {
+                            "Id": {
+                              "name": "arr2",
+                              "info": { "type_id": { "Array": "Integer" } },
+                              "position": {
+                                "start": [46, 40],
+                                "end": [46, 44],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            }
+                          },
+                          "index": {
+                            "Num": {
+                              "Integer": [
+                                3,
+                                { "type_id": "Integer" },
+                                {
+                                  "start": [46, 45],
+                                  "end": [46, 46],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              ]
+                            }
+                          },
+                          "info": { "type_id": "Integer" },
+                          "position": {
+                            "start": [46, 44],
+                            "end": [46, 45],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [46, 31],
+                    "end": [46, 32],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [46, 4],
+              "end": [46, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "my_struct",
+              "info": {
+                "type_id": {
+                  "Struct": [
+                    "TestStruct",
+                    [
+                      ["x", "Integer"],
+                      [
+                        "bar",
+                        {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      ]
+                    ]
+                  ]
+                }
+              },
+              "position": {
+                "start": [48, 8],
+                "end": [48, 17],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "StructInitialisation": {
+                "id": {
+                  "name": "TestStruct",
+                  "info": {
+                    "type_id": {
+                      "Struct": [
+                        "TestStruct",
+                        [
+                          ["x", "Integer"],
+                          [
+                            "bar",
+                            {
+                              "Function": {
+                                "params": ["Integer", "Integer"],
+                                "return_value": "Integer"
+                              }
+                            }
+                          ]
+                        ]
+                      ]
+                    }
+                  },
+                  "position": {
+                    "start": [48, 20],
+                    "end": [48, 30],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                },
+                "fields": [
+                  {
+                    "name": {
+                      "name": "x",
+                      "info": { "type_id": "Integer" },
+                      "position": {
+                        "start": [49, 8],
+                        "end": [49, 9],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    },
+                    "value": {
+                      "Num": {
+                        "Integer": [
+                          42,
+                          { "type_id": "Integer" },
+                          {
+                            "start": [49, 11],
+                            "end": [49, 13],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        ]
+                      }
+                    },
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [49, 8],
+                      "end": [49, 9],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  },
+                  {
+                    "name": {
+                      "name": "bar",
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [50, 8],
+                        "end": [50, 11],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    },
+                    "value": {
+                      "Id": {
+                        "name": "add",
+                        "info": {
+                          "type_id": {
+                            "Function": {
+                              "params": ["Integer", "Integer"],
+                              "return_value": "Integer"
+                            }
+                          }
+                        },
+                        "position": {
+                          "start": [50, 13],
+                          "end": [50, 16],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    },
+                    "info": {
+                      "type_id": {
+                        "Function": {
+                          "params": ["Integer", "Integer"],
+                          "return_value": "Integer"
+                        }
+                      }
+                    },
+                    "position": {
+                      "start": [50, 8],
+                      "end": [50, 11],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                ],
+                "info": {
+                  "type_id": {
+                    "Struct": [
+                      "TestStruct",
+                      [
+                        ["x", "Integer"],
+                        [
+                          "bar",
+                          {
+                            "Function": {
+                              "params": ["Integer", "Integer"],
+                              "return_value": "Integer"
+                            }
+                          }
+                        ]
+                      ]
+                    ]
+                  }
+                },
+                "position": {
+                  "start": [48, 20],
+                  "end": [48, 30],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [48, 4],
+              "end": [48, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "i",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [53, 12],
+                "end": [53, 13],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": true,
+            "type_name": null,
+            "value": {
+              "Num": {
+                "Integer": [
+                  0,
+                  { "type_id": "Integer" },
+                  {
+                    "start": [53, 16],
+                    "end": [53, 17],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                ]
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [53, 4],
+              "end": [53, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "WhileLoop": {
+            "condition": {
+              "Binary": {
+                "left": {
+                  "Id": {
+                    "name": "i",
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [55, 11],
+                      "end": [55, 12],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                },
+                "right": {
+                  "Num": {
+                    "Integer": [
+                      10,
+                      { "type_id": "Integer" },
+                      {
+                        "start": [55, 15],
+                        "end": [55, 17],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    ]
+                  }
+                },
+                "operator": "LessThan",
+                "info": { "type_id": "Boolean" },
+                "position": {
+                  "start": [55, 13],
+                  "end": [55, 14],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "block": {
+              "statements": [
+                {
+                  "Assignment": {
+                    "lvalue": {
+                      "Id": {
+                        "name": "i",
+                        "info": { "type_id": "Integer" },
+                        "position": {
+                          "start": [56, 8],
+                          "end": [56, 9],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    },
+                    "rvalue": {
+                      "Binary": {
+                        "left": {
+                          "Id": {
+                            "name": "i",
+                            "info": { "type_id": "Integer" },
+                            "position": {
+                              "start": [56, 12],
+                              "end": [56, 13],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          }
+                        },
+                        "right": {
+                          "Num": {
+                            "Integer": [
+                              1,
+                              { "type_id": "Integer" },
+                              {
+                                "start": [56, 16],
+                                "end": [56, 17],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            ]
+                          }
+                        },
+                        "operator": "Add",
+                        "info": { "type_id": "Integer" },
+                        "position": {
+                          "start": [56, 14],
+                          "end": [56, 15],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    },
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [56, 8],
+                      "end": [56, 15],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                }
+              ],
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [55, 19],
+                "end": [55, 20],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [55, 4],
+              "end": [55, 9],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "x",
+              "info": {
+                "type_id": {
+                  "Function": {
+                    "params": ["Integer"],
+                    "return_value": "Integer"
+                  }
+                }
+              },
+              "position": {
+                "start": [59, 8],
+                "end": [59, 9],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": {
+              "Fn": {
+                "params": [
+                  {
+                    "Literal": [
+                      "i64",
+                      {
+                        "start": [59, 12],
+                        "end": [59, 15],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    ]
+                  }
+                ],
+                "return_type": {
+                  "Literal": [
+                    "i64",
+                    {
+                      "start": [59, 20],
+                      "end": [59, 23],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  ]
+                },
+                "position": {
+                  "start": [59, 11],
+                  "end": [59, 23],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "value": {
+              "Lambda": {
+                "parameters": [
+                  {
+                    "name": {
+                      "name": "x",
+                      "info": { "type_id": "Integer" },
+                      "position": {
+                        "start": [59, 28],
+                        "end": [59, 29],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    },
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [59, 28],
+                      "end": [59, 29],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                ],
+                "expression": {
+                  "Id": {
+                    "name": "x",
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [59, 34],
+                      "end": [59, 35],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                },
+                "info": {
+                  "type_id": {
+                    "Function": {
+                      "params": ["Integer"],
+                      "return_value": "Integer"
+                    }
+                  }
+                },
+                "position": {
+                  "start": [59, 26],
+                  "end": [59, 27],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [59, 4],
+              "end": [59, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "test_char",
+              "info": { "type_id": "Character" },
+              "position": {
+                "start": [61, 8],
+                "end": [61, 17],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Character": {
+                "character": "a",
+                "position": {
+                  "start": [61, 20],
+                  "end": [61, 23],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                },
+                "info": { "type_id": "Character" }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [61, 4],
+              "end": [61, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "foo",
+              "info": { "type_id": { "Array": "Character" } },
+              "position": {
+                "start": [63, 12],
+                "end": [63, 15],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": true,
+            "type_name": null,
+            "value": {
+              "Array": {
+                "Literal": {
+                  "values": [
+                    {
+                      "Id": {
+                        "name": "test_char",
+                        "info": { "type_id": "Character" },
+                        "position": {
+                          "start": [63, 19],
+                          "end": [63, 28],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    },
+                    {
+                      "Character": {
+                        "character": "b",
+                        "position": {
+                          "start": [63, 30],
+                          "end": [63, 33],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        },
+                        "info": { "type_id": "Character" }
+                      }
+                    }
+                  ],
+                  "info": { "type_id": { "Array": "Character" } },
+                  "position": {
+                    "start": [63, 18],
+                    "end": [63, 19],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [63, 4],
+              "end": [63, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Assignment": {
+            "lvalue": {
+              "Postfix": {
+                "Index": {
+                  "expr": {
+                    "Id": {
+                      "name": "foo",
+                      "info": { "type_id": { "Array": "Character" } },
+                      "position": {
+                        "start": [65, 4],
+                        "end": [65, 7],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  },
+                  "index": {
+                    "Num": {
+                      "Integer": [
+                        1,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [65, 8],
+                          "end": [65, 9],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  },
+                  "info": { "type_id": "Character" },
+                  "position": {
+                    "start": [65, 7],
+                    "end": [65, 8],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "rvalue": {
+              "Id": {
+                "name": "test_char",
+                "info": { "type_id": "Character" },
+                "position": {
+                  "start": [65, 13],
+                  "end": [65, 22],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "info": { "type_id": "Character" },
+            "position": {
+              "start": [65, 4],
+              "end": [65, 22],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "test_str",
+              "info": { "type_id": "String" },
+              "position": {
+                "start": [67, 8],
+                "end": [67, 16],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "AstString": {
+                "value": "test",
+                "info": { "type_id": "String" },
+                "position": {
+                  "start": [67, 19],
+                  "end": [67, 25],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [67, 4],
+              "end": [67, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "len",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [69, 8],
+                "end": [69, 11],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Postfix": {
+                "Call": {
+                  "expr": {
+                    "Postfix": {
+                      "PropertyAccess": {
+                        "expr": {
+                          "Id": {
+                            "name": "test_str",
+                            "info": { "type_id": "String" },
+                            "position": {
+                              "start": [69, 14],
+                              "end": [69, 22],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          }
+                        },
+                        "property": {
+                          "name": "len",
+                          "info": {
+                            "type_id": {
+                              "Function": {
+                                "params": [],
+                                "return_value": "Integer"
+                              }
+                            }
+                          },
+                          "position": {
+                            "start": [69, 23],
+                            "end": [69, 26],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        },
+                        "info": {
+                          "type_id": {
+                            "Function": {
+                              "params": [],
+                              "return_value": "Integer"
+                            }
+                          }
+                        },
+                        "position": {
+                          "start": [69, 22],
+                          "end": [69, 23],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    }
+                  },
+                  "args": [],
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [69, 26],
+                    "end": [69, 27],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [69, 4],
+              "end": [69, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Expression": {
+            "Postfix": {
+              "Call": {
+                "expr": {
+                  "Id": {
+                    "name": "takes_function",
+                    "info": {
+                      "type_id": {
+                        "Function": {
+                          "params": [
+                            {
+                              "Function": {
+                                "params": ["Integer", "Integer"],
+                                "return_value": "Integer"
+                              }
+                            }
+                          ],
+                          "return_value": "Integer"
+                        }
+                      }
+                    },
+                    "position": {
+                      "start": [71, 4],
+                      "end": [71, 18],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                },
+                "args": [
+                  {
+                    "Id": {
+                      "name": "add",
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [71, 19],
+                        "end": [71, 22],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  }
+                ],
+                "info": { "type_id": "Integer" },
+                "position": {
+                  "start": [71, 18],
+                  "end": [71, 19],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            }
+          }
+        },
+        {
+          "Expression": {
+            "Postfix": {
+              "Call": {
+                "expr": {
+                  "Id": {
+                    "name": "takes_function",
+                    "info": {
+                      "type_id": {
+                        "Function": {
+                          "params": [
+                            {
+                              "Function": {
+                                "params": ["Integer", "Integer"],
+                                "return_value": "Integer"
+                              }
+                            }
+                          ],
+                          "return_value": "Integer"
+                        }
+                      }
+                    },
+                    "position": {
+                      "start": [72, 4],
+                      "end": [72, 18],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                },
+                "args": [
+                  {
+                    "Id": {
+                      "name": "explicit_return_add",
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [72, 19],
+                        "end": [72, 38],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  }
+                ],
+                "info": { "type_id": "Integer" },
+                "position": {
+                  "start": [72, 18],
+                  "end": [72, 19],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "b",
+              "info": {
+                "type_id": {
+                  "Struct": [
+                    "Bar",
+                    [
+                      [
+                        "t",
+                        {
+                          "Struct": [
+                            "TestStruct",
+                            [
+                              ["x", "Integer"],
+                              [
+                                "bar",
+                                {
+                                  "Function": {
+                                    "params": ["Integer", "Integer"],
+                                    "return_value": "Integer"
+                                  }
+                                }
+                              ]
+                            ]
+                          ]
+                        }
+                      ]
+                    ]
+                  ]
+                }
+              },
+              "position": {
+                "start": [74, 12],
+                "end": [74, 13],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": true,
+            "type_name": null,
+            "value": {
+              "StructInitialisation": {
+                "id": {
+                  "name": "Bar",
+                  "info": {
+                    "type_id": {
+                      "Struct": [
+                        "Bar",
+                        [
+                          [
+                            "t",
+                            {
+                              "Struct": [
+                                "TestStruct",
+                                [
+                                  ["x", "Integer"],
+                                  [
+                                    "bar",
+                                    {
+                                      "Function": {
+                                        "params": ["Integer", "Integer"],
+                                        "return_value": "Integer"
+                                      }
+                                    }
+                                  ]
+                                ]
+                              ]
+                            }
+                          ]
+                        ]
+                      ]
+                    }
+                  },
+                  "position": {
+                    "start": [74, 16],
+                    "end": [74, 19],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                },
+                "fields": [
+                  {
+                    "name": {
+                      "name": "t",
+                      "info": {
+                        "type_id": {
+                          "Struct": [
+                            "TestStruct",
+                            [
+                              ["x", "Integer"],
+                              [
+                                "bar",
+                                {
+                                  "Function": {
+                                    "params": ["Integer", "Integer"],
+                                    "return_value": "Integer"
+                                  }
+                                }
+                              ]
+                            ]
+                          ]
+                        }
+                      },
+                      "position": {
+                        "start": [75, 8],
+                        "end": [75, 9],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    },
+                    "value": {
+                      "StructInitialisation": {
+                        "id": {
+                          "name": "TestStruct",
+                          "info": {
+                            "type_id": {
+                              "Struct": [
+                                "TestStruct",
+                                [
+                                  ["x", "Integer"],
+                                  [
+                                    "bar",
+                                    {
+                                      "Function": {
+                                        "params": ["Integer", "Integer"],
+                                        "return_value": "Integer"
+                                      }
+                                    }
+                                  ]
+                                ]
+                              ]
+                            }
+                          },
+                          "position": {
+                            "start": [75, 11],
+                            "end": [75, 21],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        },
+                        "fields": [
+                          {
+                            "name": {
+                              "name": "x",
+                              "info": { "type_id": "Integer" },
+                              "position": {
+                                "start": [76, 12],
+                                "end": [76, 13],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            },
+                            "value": {
+                              "Num": {
+                                "Integer": [
+                                  1337,
+                                  { "type_id": "Integer" },
+                                  {
+                                    "start": [76, 15],
+                                    "end": [76, 19],
+                                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                  }
+                                ]
+                              }
+                            },
+                            "info": { "type_id": "Integer" },
+                            "position": {
+                              "start": [76, 12],
+                              "end": [76, 13],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          },
+                          {
+                            "name": {
+                              "name": "bar",
+                              "info": {
+                                "type_id": {
+                                  "Function": {
+                                    "params": ["Integer", "Integer"],
+                                    "return_value": "Integer"
+                                  }
+                                }
+                              },
+                              "position": {
+                                "start": [77, 12],
+                                "end": [77, 15],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            },
+                            "value": {
+                              "Id": {
+                                "name": "add",
+                                "info": {
+                                  "type_id": {
+                                    "Function": {
+                                      "params": ["Integer", "Integer"],
+                                      "return_value": "Integer"
+                                    }
+                                  }
+                                },
+                                "position": {
+                                  "start": [77, 17],
+                                  "end": [77, 20],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              }
+                            },
+                            "info": {
+                              "type_id": {
+                                "Function": {
+                                  "params": ["Integer", "Integer"],
+                                  "return_value": "Integer"
+                                }
+                              }
+                            },
+                            "position": {
+                              "start": [77, 12],
+                              "end": [77, 15],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          }
+                        ],
+                        "info": {
+                          "type_id": {
+                            "Struct": [
+                              "TestStruct",
+                              [
+                                ["x", "Integer"],
+                                [
+                                  "bar",
+                                  {
+                                    "Function": {
+                                      "params": ["Integer", "Integer"],
+                                      "return_value": "Integer"
+                                    }
+                                  }
+                                ]
+                              ]
+                            ]
+                          }
+                        },
+                        "position": {
+                          "start": [75, 11],
+                          "end": [75, 21],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    },
+                    "info": {
+                      "type_id": {
+                        "Struct": [
+                          "TestStruct",
+                          [
+                            ["x", "Integer"],
+                            [
+                              "bar",
+                              {
+                                "Function": {
+                                  "params": ["Integer", "Integer"],
+                                  "return_value": "Integer"
+                                }
+                              }
+                            ]
+                          ]
+                        ]
+                      }
+                    },
+                    "position": {
+                      "start": [75, 8],
+                      "end": [75, 9],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  }
+                ],
+                "info": {
+                  "type_id": {
+                    "Struct": [
+                      "Bar",
+                      [
+                        [
+                          "t",
+                          {
+                            "Struct": [
+                              "TestStruct",
+                              [
+                                ["x", "Integer"],
+                                [
+                                  "bar",
+                                  {
+                                    "Function": {
+                                      "params": ["Integer", "Integer"],
+                                      "return_value": "Integer"
+                                    }
+                                  }
+                                ]
+                              ]
+                            ]
+                          }
+                        ]
+                      ]
+                    ]
+                  }
+                },
+                "position": {
+                  "start": [74, 16],
+                  "end": [74, 19],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [74, 4],
+              "end": [74, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Assignment": {
+            "lvalue": {
+              "Postfix": {
+                "PropertyAccess": {
+                  "expr": {
+                    "Postfix": {
+                      "PropertyAccess": {
+                        "expr": {
+                          "Id": {
+                            "name": "b",
+                            "info": {
+                              "type_id": {
+                                "Struct": [
+                                  "Bar",
+                                  [
+                                    [
+                                      "t",
+                                      {
+                                        "Struct": [
+                                          "TestStruct",
+                                          [
+                                            ["x", "Integer"],
+                                            [
+                                              "bar",
+                                              {
+                                                "Function": {
+                                                  "params": [
+                                                    "Integer",
+                                                    "Integer"
+                                                  ],
+                                                  "return_value": "Integer"
+                                                }
+                                              }
+                                            ]
+                                          ]
+                                        ]
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              }
+                            },
+                            "position": {
+                              "start": [81, 4],
+                              "end": [81, 5],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          }
+                        },
+                        "property": {
+                          "name": "t",
+                          "info": {
+                            "type_id": {
+                              "Struct": [
+                                "TestStruct",
+                                [
+                                  ["x", "Integer"],
+                                  [
+                                    "bar",
+                                    {
+                                      "Function": {
+                                        "params": ["Integer", "Integer"],
+                                        "return_value": "Integer"
+                                      }
+                                    }
+                                  ]
+                                ]
+                              ]
+                            }
+                          },
+                          "position": {
+                            "start": [81, 6],
+                            "end": [81, 7],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        },
+                        "info": {
+                          "type_id": {
+                            "Struct": [
+                              "TestStruct",
+                              [
+                                ["x", "Integer"],
+                                [
+                                  "bar",
+                                  {
+                                    "Function": {
+                                      "params": ["Integer", "Integer"],
+                                      "return_value": "Integer"
+                                    }
+                                  }
+                                ]
+                              ]
+                            ]
+                          }
+                        },
+                        "position": {
+                          "start": [81, 5],
+                          "end": [81, 6],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    }
+                  },
+                  "property": {
+                    "name": "x",
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [81, 8],
+                      "end": [81, 9],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  },
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [81, 7],
+                    "end": [81, 8],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "rvalue": {
+              "Num": {
+                "Integer": [
+                  42,
+                  { "type_id": "Integer" },
+                  {
+                    "start": [81, 12],
+                    "end": [81, 14],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                ]
+              }
+            },
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [81, 4],
+              "end": [81, 14],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Assignment": {
+            "lvalue": {
+              "Postfix": {
+                "Index": {
+                  "expr": {
+                    "Id": {
+                      "name": "arr",
+                      "info": { "type_id": { "Array": "Integer" } },
+                      "position": {
+                        "start": [83, 4],
+                        "end": [83, 7],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  },
+                  "index": {
+                    "Num": {
+                      "Integer": [
+                        5,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [83, 8],
+                          "end": [83, 9],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  },
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [83, 7],
+                    "end": [83, 8],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "rvalue": {
+              "Num": {
+                "Integer": [
+                  1337,
+                  { "type_id": "Integer" },
+                  {
+                    "start": [83, 13],
+                    "end": [83, 17],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                ]
+              }
+            },
+            "info": { "type_id": "Integer" },
+            "position": {
+              "start": [83, 4],
+              "end": [83, 17],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Expression": {
+            "Postfix": {
+              "Call": {
+                "expr": {
+                  "Postfix": {
+                    "PropertyAccess": {
+                      "expr": {
+                        "Postfix": {
+                          "PropertyAccess": {
+                            "expr": {
+                              "Id": {
+                                "name": "b",
+                                "info": {
+                                  "type_id": {
+                                    "Struct": [
+                                      "Bar",
+                                      [
+                                        [
+                                          "t",
+                                          {
+                                            "Struct": [
+                                              "TestStruct",
+                                              [
+                                                ["x", "Integer"],
+                                                [
+                                                  "bar",
+                                                  {
+                                                    "Function": {
+                                                      "params": [
+                                                        "Integer",
+                                                        "Integer"
+                                                      ],
+                                                      "return_value": "Integer"
+                                                    }
+                                                  }
+                                                ]
+                                              ]
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "position": {
+                                  "start": [85, 4],
+                                  "end": [85, 5],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              }
+                            },
+                            "property": {
+                              "name": "t",
+                              "info": {
+                                "type_id": {
+                                  "Struct": [
+                                    "TestStruct",
+                                    [
+                                      ["x", "Integer"],
+                                      [
+                                        "bar",
+                                        {
+                                          "Function": {
+                                            "params": ["Integer", "Integer"],
+                                            "return_value": "Integer"
+                                          }
+                                        }
+                                      ]
+                                    ]
+                                  ]
+                                }
+                              },
+                              "position": {
+                                "start": [85, 6],
+                                "end": [85, 7],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            },
+                            "info": {
+                              "type_id": {
+                                "Struct": [
+                                  "TestStruct",
+                                  [
+                                    ["x", "Integer"],
+                                    [
+                                      "bar",
+                                      {
+                                        "Function": {
+                                          "params": ["Integer", "Integer"],
+                                          "return_value": "Integer"
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              }
+                            },
+                            "position": {
+                              "start": [85, 5],
+                              "end": [85, 6],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          }
+                        }
+                      },
+                      "property": {
+                        "name": "bar",
+                        "info": {
+                          "type_id": {
+                            "Function": {
+                              "params": ["Integer", "Integer"],
+                              "return_value": "Integer"
+                            }
+                          }
+                        },
+                        "position": {
+                          "start": [85, 8],
+                          "end": [85, 11],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      },
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [85, 7],
+                        "end": [85, 8],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  }
+                },
+                "args": [
+                  {
+                    "Num": {
+                      "Integer": [
+                        4,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [85, 12],
+                          "end": [85, 13],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "Num": {
+                      "Integer": [
+                        2,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [85, 15],
+                          "end": [85, 16],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "info": { "type_id": "Integer" },
+                "position": {
+                  "start": [85, 11],
+                  "end": [85, 12],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            }
+          }
+        },
+        {
+          "Expression": {
+            "Postfix": {
+              "Call": {
+                "expr": {
+                  "Postfix": {
+                    "PropertyAccess": {
+                      "expr": {
+                        "Postfix": {
+                          "PropertyAccess": {
+                            "expr": {
+                              "Id": {
+                                "name": "b",
+                                "info": {
+                                  "type_id": {
+                                    "Struct": [
+                                      "Bar",
+                                      [
+                                        [
+                                          "t",
+                                          {
+                                            "Struct": [
+                                              "TestStruct",
+                                              [
+                                                ["x", "Integer"],
+                                                [
+                                                  "bar",
+                                                  {
+                                                    "Function": {
+                                                      "params": [
+                                                        "Integer",
+                                                        "Integer"
+                                                      ],
+                                                      "return_value": "Integer"
+                                                    }
+                                                  }
+                                                ]
+                                              ]
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "position": {
+                                  "start": [87, 4],
+                                  "end": [87, 5],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              }
+                            },
+                            "property": {
+                              "name": "t",
+                              "info": {
+                                "type_id": {
+                                  "Struct": [
+                                    "TestStruct",
+                                    [
+                                      ["x", "Integer"],
+                                      [
+                                        "bar",
+                                        {
+                                          "Function": {
+                                            "params": ["Integer", "Integer"],
+                                            "return_value": "Integer"
+                                          }
+                                        }
+                                      ]
+                                    ]
+                                  ]
+                                }
+                              },
+                              "position": {
+                                "start": [87, 6],
+                                "end": [87, 7],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            },
+                            "info": {
+                              "type_id": {
+                                "Struct": [
+                                  "TestStruct",
+                                  [
+                                    ["x", "Integer"],
+                                    [
+                                      "bar",
+                                      {
+                                        "Function": {
+                                          "params": ["Integer", "Integer"],
+                                          "return_value": "Integer"
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              }
+                            },
+                            "position": {
+                              "start": [87, 5],
+                              "end": [87, 6],
+                              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                            }
+                          }
+                        }
+                      },
+                      "property": {
+                        "name": "set_x",
+                        "info": {
+                          "type_id": {
+                            "Function": {
+                              "params": ["Integer"],
+                              "return_value": "Void"
+                            }
+                          }
+                        },
+                        "position": {
+                          "start": [87, 8],
+                          "end": [87, 13],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      },
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer"],
+                            "return_value": "Void"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [87, 7],
+                        "end": [87, 8],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  }
+                },
+                "args": [
+                  {
+                    "Num": {
+                      "Integer": [
+                        1337,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [87, 14],
+                          "end": [87, 18],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "info": { "type_id": "Void" },
+                "position": {
+                  "start": [87, 13],
+                  "end": [87, 14],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              }
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "value_of_x",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [89, 8],
+                "end": [89, 18],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Postfix": {
+                "Call": {
+                  "expr": {
+                    "Postfix": {
+                      "PropertyAccess": {
+                        "expr": {
+                          "Postfix": {
+                            "PropertyAccess": {
+                              "expr": {
+                                "Id": {
+                                  "name": "b",
+                                  "info": {
+                                    "type_id": {
+                                      "Struct": [
+                                        "Bar",
+                                        [
+                                          [
+                                            "t",
+                                            {
+                                              "Struct": [
+                                                "TestStruct",
+                                                [
+                                                  ["x", "Integer"],
+                                                  [
+                                                    "bar",
+                                                    {
+                                                      "Function": {
+                                                        "params": [
+                                                          "Integer",
+                                                          "Integer"
+                                                        ],
+                                                        "return_value": "Integer"
+                                                      }
+                                                    }
+                                                  ]
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  "position": {
+                                    "start": [89, 21],
+                                    "end": [89, 22],
+                                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                  }
+                                }
+                              },
+                              "property": {
+                                "name": "t",
+                                "info": {
+                                  "type_id": {
+                                    "Struct": [
+                                      "TestStruct",
+                                      [
+                                        ["x", "Integer"],
+                                        [
+                                          "bar",
+                                          {
+                                            "Function": {
+                                              "params": ["Integer", "Integer"],
+                                              "return_value": "Integer"
+                                            }
+                                          }
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "position": {
+                                  "start": [89, 23],
+                                  "end": [89, 24],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              },
+                              "info": {
+                                "type_id": {
+                                  "Struct": [
+                                    "TestStruct",
+                                    [
+                                      ["x", "Integer"],
+                                      [
+                                        "bar",
+                                        {
+                                          "Function": {
+                                            "params": ["Integer", "Integer"],
+                                            "return_value": "Integer"
+                                          }
+                                        }
+                                      ]
+                                    ]
+                                  ]
+                                }
+                              },
+                              "position": {
+                                "start": [89, 22],
+                                "end": [89, 23],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            }
+                          }
+                        },
+                        "property": {
+                          "name": "get_x",
+                          "info": {
+                            "type_id": {
+                              "Function": {
+                                "params": [],
+                                "return_value": "Integer"
+                              }
+                            }
+                          },
+                          "position": {
+                            "start": [89, 25],
+                            "end": [89, 30],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        },
+                        "info": {
+                          "type_id": {
+                            "Function": {
+                              "params": [],
+                              "return_value": "Integer"
+                            }
+                          }
+                        },
+                        "position": {
+                          "start": [89, 24],
+                          "end": [89, 25],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    }
+                  },
+                  "args": [],
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [89, 30],
+                    "end": [89, 31],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [89, 4],
+              "end": [89, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        },
+        {
+          "Initialization": {
+            "id": {
+              "name": "id",
+              "info": { "type_id": "Integer" },
+              "position": {
+                "start": [91, 8],
+                "end": [91, 10],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            },
+            "mutable": false,
+            "type_name": null,
+            "value": {
+              "Postfix": {
+                "Call": {
+                  "expr": {
+                    "Postfix": {
+                      "PropertyAccess": {
+                        "expr": {
+                          "Postfix": {
+                            "PropertyAccess": {
+                              "expr": {
+                                "Id": {
+                                  "name": "b",
+                                  "info": {
+                                    "type_id": {
+                                      "Struct": [
+                                        "Bar",
+                                        [
+                                          [
+                                            "t",
+                                            {
+                                              "Struct": [
+                                                "TestStruct",
+                                                [
+                                                  ["x", "Integer"],
+                                                  [
+                                                    "bar",
+                                                    {
+                                                      "Function": {
+                                                        "params": [
+                                                          "Integer",
+                                                          "Integer"
+                                                        ],
+                                                        "return_value": "Integer"
+                                                      }
+                                                    }
+                                                  ]
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  "position": {
+                                    "start": [91, 13],
+                                    "end": [91, 14],
+                                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                  }
+                                }
+                              },
+                              "property": {
+                                "name": "t",
+                                "info": {
+                                  "type_id": {
+                                    "Struct": [
+                                      "TestStruct",
+                                      [
+                                        ["x", "Integer"],
+                                        [
+                                          "bar",
+                                          {
+                                            "Function": {
+                                              "params": ["Integer", "Integer"],
+                                              "return_value": "Integer"
+                                            }
+                                          }
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "position": {
+                                  "start": [91, 15],
+                                  "end": [91, 16],
+                                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                                }
+                              },
+                              "info": {
+                                "type_id": {
+                                  "Struct": [
+                                    "TestStruct",
+                                    [
+                                      ["x", "Integer"],
+                                      [
+                                        "bar",
+                                        {
+                                          "Function": {
+                                            "params": ["Integer", "Integer"],
+                                            "return_value": "Integer"
+                                          }
+                                        }
+                                      ]
+                                    ]
+                                  ]
+                                }
+                              },
+                              "position": {
+                                "start": [91, 14],
+                                "end": [91, 15],
+                                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                              }
+                            }
+                          }
+                        },
+                        "property": {
+                          "name": "get_id",
+                          "info": {
+                            "type_id": {
+                              "Function": {
+                                "params": [],
+                                "return_value": "Integer"
+                              }
+                            }
+                          },
+                          "position": {
+                            "start": [91, 17],
+                            "end": [91, 23],
+                            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                          }
+                        },
+                        "info": {
+                          "type_id": {
+                            "Function": {
+                              "params": [],
+                              "return_value": "Integer"
+                            }
+                          }
+                        },
+                        "position": {
+                          "start": [91, 16],
+                          "end": [91, 17],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      }
+                    }
+                  },
+                  "args": [],
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [91, 23],
+                    "end": [91, 24],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              }
+            },
+            "info": { "type_id": "Void" },
+            "position": {
+              "start": [91, 4],
+              "end": [91, 7],
+              "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+            }
+          }
+        }
+      ],
+      "info": {
+        "type_id": { "Function": { "params": [], "return_value": "Void" } }
+      },
+      "position": {
+        "start": [39, 0],
+        "end": [39, 2],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Function": {
+      "id": {
+        "name": "asd",
+        "info": {
+          "type_id": {
+            "Function": {
+              "params": [],
+              "return_value": {
+                "Struct": [
+                  "TestStruct",
+                  [
+                    ["x", "Integer"],
+                    [
+                      "bar",
+                      {
+                        "Function": {
+                          "params": ["Integer", "Integer"],
+                          "return_value": "Integer"
+                        }
+                      }
+                    ]
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "position": {
+          "start": [94, 3],
+          "end": [94, 6],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "parameters": [],
+      "return_type": {
+        "Literal": [
+          "TestStruct",
+          {
+            "start": [94, 10],
+            "end": [94, 20],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        ]
+      },
+      "statements": [
+        {
+          "Return": {
+            "StructInitialisation": {
+              "id": {
+                "name": "TestStruct",
+                "info": {
+                  "type_id": {
+                    "Struct": [
+                      "TestStruct",
+                      [
+                        ["x", "Integer"],
+                        [
+                          "bar",
+                          {
+                            "Function": {
+                              "params": ["Integer", "Integer"],
+                              "return_value": "Integer"
+                            }
+                          }
+                        ]
+                      ]
+                    ]
+                  }
+                },
+                "position": {
+                  "start": [95, 11],
+                  "end": [95, 21],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              },
+              "fields": [
+                {
+                  "name": {
+                    "name": "x",
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [96, 8],
+                      "end": [96, 9],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  },
+                  "value": {
+                    "Num": {
+                      "Integer": [
+                        42,
+                        { "type_id": "Integer" },
+                        {
+                          "start": [96, 11],
+                          "end": [96, 13],
+                          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                        }
+                      ]
+                    }
+                  },
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [96, 8],
+                    "end": [96, 9],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                },
+                {
+                  "name": {
+                    "name": "bar",
+                    "info": {
+                      "type_id": {
+                        "Function": {
+                          "params": ["Integer", "Integer"],
+                          "return_value": "Integer"
+                        }
+                      }
+                    },
+                    "position": {
+                      "start": [97, 8],
+                      "end": [97, 11],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  },
+                  "value": {
+                    "Id": {
+                      "name": "add",
+                      "info": {
+                        "type_id": {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      },
+                      "position": {
+                        "start": [97, 13],
+                        "end": [97, 16],
+                        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                      }
+                    }
+                  },
+                  "info": {
+                    "type_id": {
+                      "Function": {
+                        "params": ["Integer", "Integer"],
+                        "return_value": "Integer"
+                      }
+                    }
+                  },
+                  "position": {
+                    "start": [97, 8],
+                    "end": [97, 11],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              ],
+              "info": {
+                "type_id": {
+                  "Struct": [
+                    "TestStruct",
+                    [
+                      ["x", "Integer"],
+                      [
+                        "bar",
+                        {
+                          "Function": {
+                            "params": ["Integer", "Integer"],
+                            "return_value": "Integer"
+                          }
+                        }
+                      ]
+                    ]
+                  ]
+                }
+              },
+              "position": {
+                "start": [95, 11],
+                "end": [95, 21],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          }
+        }
+      ],
+      "info": {
+        "type_id": {
+          "Function": {
+            "params": [],
+            "return_value": {
+              "Struct": [
+                "TestStruct",
+                [
+                  ["x", "Integer"],
+                  [
+                    "bar",
+                    {
+                      "Function": {
+                        "params": ["Integer", "Integer"],
+                        "return_value": "Integer"
+                      }
+                    }
+                  ]
+                ]
+              ]
+            }
+          }
+        }
+      },
+      "position": {
+        "start": [94, 0],
+        "end": [94, 2],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  },
+  {
+    "Function": {
+      "id": {
+        "name": "foobar",
+        "info": {
+          "type_id": {
+            "Function": {
+              "params": [],
+              "return_value": {
+                "Function": { "params": ["Integer"], "return_value": "Integer" }
+              }
+            }
+          }
+        },
+        "position": {
+          "start": [101, 3],
+          "end": [101, 9],
+          "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+        }
+      },
+      "parameters": [],
+      "return_type": {
+        "Fn": {
+          "params": [
+            {
+              "Literal": [
+                "i64",
+                {
+                  "start": [101, 14],
+                  "end": [101, 17],
+                  "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                }
+              ]
+            }
+          ],
+          "return_type": {
+            "Literal": [
+              "i64",
+              {
+                "start": [101, 22],
+                "end": [101, 25],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            ]
+          },
+          "position": {
+            "start": [101, 13],
+            "end": [101, 25],
+            "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+          }
+        }
+      },
+      "statements": [
+        {
+          "Return": {
+            "Lambda": {
+              "parameters": [
+                {
+                  "name": {
+                    "name": "x",
+                    "info": { "type_id": "Integer" },
+                    "position": {
+                      "start": [102, 13],
+                      "end": [102, 14],
+                      "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                    }
+                  },
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [102, 13],
+                    "end": [102, 14],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              ],
+              "expression": {
+                "Id": {
+                  "name": "x",
+                  "info": { "type_id": "Integer" },
+                  "position": {
+                    "start": [102, 19],
+                    "end": [102, 20],
+                    "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+                  }
+                }
+              },
+              "info": {
+                "type_id": {
+                  "Function": {
+                    "params": ["Integer"],
+                    "return_value": "Integer"
+                  }
+                }
+              },
+              "position": {
+                "start": [102, 11],
+                "end": [102, 12],
+                "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+              }
+            }
+          }
+        }
+      ],
+      "info": {
+        "type_id": {
+          "Function": {
+            "params": [],
+            "return_value": {
+              "Function": { "params": ["Integer"], "return_value": "Integer" }
+            }
+          }
+        }
+      },
+      "position": {
+        "start": [101, 0],
+        "end": [101, 2],
+        "source": "const PI: f64 = 3.1415;\n\nfn add(x: i64, y: i64): i64 {\n    x + y\n}\n\nfn explicit_return_add(x: i64, y: i64): i64 {\n    return x + y;\n}\n\nstruct TestStruct {\n    x: i64;\n    bar: (i64, i64) -> i64;\n}\n\nstruct Bar {\n    t: TestStruct;\n}\n\ninstance TestStruct {\n    declare get_id(): i64;\n\n    fn get_x(): i64 {\n        return this.x;\n    }\n\n    fn set_x(x: i64): void {\n        this.x = x;\n    }\n}\n\nfn takes_function(func: (i64, i64) -> i64): i64 {\n    func(42, 69)\n}\n\ninstance str {\n    declare len(): i64;\n}\n\nfn main(): void {\n    let a = add(42, 1337);\n\n    let mut arr = [42, 1337];\n\n    let arr2 = [1337; 5];\n\n    let b = explicit_return_add(arr[0], arr2[3]);\n\n    let my_struct = TestStruct {\n        x: 42,\n        bar: add\n    };\n\n    let mut i = 0;\n\n    while (i < 10) {\n        i = i + 1;\n    }\n\n    let x: (i64) -> i64 = \\(x) => x;\n\n    let test_char = 'a';\n\n    let mut foo = [test_char, 'b'];\n\n    foo[1] = test_char;\n\n    let test_str = \"test\";\n\n    let len = test_str.len();\n\n    takes_function(add);\n    takes_function(explicit_return_add);\n\n    let mut b = Bar {\n        t: TestStruct {\n            x: 1337,\n            bar: add\n        }\n    };\n\n    b.t.x = 42;\n\n    arr[5] = 1337;\n\n    b.t.bar(4, 2);\n\n    b.t.set_x(1337);\n\n    let value_of_x = b.t.get_x();\n\n    let id = b.t.get_id();\n}\n\nfn asd(): TestStruct {\n    return TestStruct {\n        x: 42,\n        bar: add\n    };\n}\n\nfn foobar(): (i64) -> i64 {\n    return \\(x) => x;\n}\n"
+      }
+    }
+  }
+]


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#5XcRFGAM8`](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/5XcRFGAM8)

**Make AST Serializable**


- Added serde serialization and deserialization to key AST and typechecker structs for easier debugging, testing, and data persistence.
- Skipped serialization of non-serializable context field in ValidatedTypeInformation.
- Improved error handling in the typechecker with TypeValidationError methods for consistent error messages and span access.
- Updated yls binary to return detailed error information from type checking and validation phases for enhanced diagnostics.

4 commit series (version 5)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 4/4 | [fix(typechecker): correct main function return type check logic](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/5XcRFGAM8/commit/1d9c7281-0925-4d75-b381-0ff9d4c33684) | ⏳ |  |
| 3/4 | [feat(typechecker): add main function signature validation](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/5XcRFGAM8/commit/16b64a3f-5962-4f5b-9057-bcba8530fe43) | ⏳ |  |
| 2/4 | [feat(typechecker): improve error handling for type validation](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/5XcRFGAM8/commit/18227a03-576d-4b23-aa4e-71087a891456) | ⏳ |  |
| 1/4 | [feat: add serde serialization to AST and typechecker structs](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/5XcRFGAM8/commit/e89a0255-ea78-4eac-85b0-1762180fd978) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/5XcRFGAM8)_
<!-- GitButler Review Footer Boundary Bottom -->
