### PR TITLE
feat(cli): add flags to print intermediate AST stages

### DIFF
--- a/src/bin/yc.rs
+++ b/src/bin/yc.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use pesca_lang::{Cli, compile_file};
+use pesca_lang::{VCArgs, compile_file};
 
 fn main() -> Result<()> {
-    let args = Cli::init();
+    let args = VCArgs::init();
 
     compile_file(args)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,19 @@ pub struct Cli {
     #[arg(index = 1)]
     pub file: std::path::PathBuf,
 
+    /// Print the lexed source tree.
     #[arg(short = 'l', long)]
     pub print_lexed: bool,
 
+    /// Print the parsed AST.
     #[arg(short = 'p', long)]
     pub print_parsed: bool,
 
+    /// Print the typechecked AST.
     #[arg(short = 'c', long)]
     pub print_checked: bool,
 
+    /// Print the validated AST.
     #[arg(short = 'v', long)]
     pub print_validated: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use why_lib::{lexer::Lexer, parser::parse, typechecker::TypeChecker};
 #[derive(Parser, Debug, serde::Serialize, serde::Deserialize)]
 #[command(author, version, about)]
 #[command(propagate_version = true)]
-pub struct Cli {
+pub struct VCArgs {
     /// The path to the source file.
     #[arg(index = 1)]
     pub file: std::path::PathBuf,
@@ -31,13 +31,13 @@ pub struct Cli {
     pub output: Option<std::path::PathBuf>,
 }
 
-impl Cli {
+impl VCArgs {
     pub fn init() -> Self {
-        Cli::parse()
+        VCArgs::parse()
     }
 }
 
-pub fn compile_file(args: Cli) -> anyhow::Result<()> {
+pub fn compile_file(args: VCArgs) -> anyhow::Result<()> {
     let input = fs::read_to_string(args.file)?;
 
     let lexer = Lexer::new(&input);


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#4ARyo5v3z`](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/4ARyo5v3z)

**feat(cli): add flags to print intermediate AST stages**


Add command-line options to print the lexed source tree, parsed AST,typechecked AST, and validated AST. These flags help with debugging andunderstanding the compilation process by allowing users to inspect eachstage of the AST transformation.

2 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [refactor(cli): rename Cli to VCArgs for clarity](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/4ARyo5v3z/commit/04e19339-c757-4e43-b17d-cc4144e6c97b) | ⏳ |  |
| 1/2 | [feat(cli): add flags to print intermediate AST stages](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/4ARyo5v3z/commit/1636d4ee-b31b-48db-85cb-38fdafd23374) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/4ARyo5v3z)_
<!-- GitButler Review Footer Boundary Bottom -->
