### PR TITLE
feat(typechecker): add UnsupportedBinaryOperation error for binary ops

### DIFF
--- a/crates/why_lib/src/typechecker/error.rs
+++ b/crates/why_lib/src/typechecker/error.rs
@@ -17,6 +17,7 @@ pub enum TypeCheckError {
     ImmutableReassign(ImmutableReassign, Span),
     MissingMainFunction(MissingMainFunction),
     InvalidMainSignature(InvalidMainSignature, Span),
+    UnsupportedBinaryOperation(UnsupportedBinaryOperation, Span),
 }
 
 impl Display for TypeCheckError {
@@ -39,6 +40,7 @@ impl TypeCheckError {
             TypeCheckError::ImmutableReassign(_, span) => span.clone(),
             TypeCheckError::MissingMainFunction(_) => Span::default(),
             TypeCheckError::InvalidMainSignature(_, span) => span.clone(),
+            TypeCheckError::UnsupportedBinaryOperation(_, span) => span.clone(),
         }
     }
 
@@ -55,6 +57,7 @@ impl TypeCheckError {
             TypeCheckError::ImmutableReassign(e, _) => Box::new(e.clone()),
             TypeCheckError::MissingMainFunction(e) => Box::new(e.clone()),
             TypeCheckError::InvalidMainSignature(e, _) => Box::new(e.clone()),
+            TypeCheckError::UnsupportedBinaryOperation(e, _) => Box::new(e.clone()),
         }
     }
 }
@@ -220,3 +223,23 @@ impl Display for InvalidMainSignature {
 }
 
 impl Error for InvalidMainSignature {}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct UnsupportedBinaryOperation {
+    pub operands: (Type, Type),
+}
+
+impl Display for UnsupportedBinaryOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let UnsupportedBinaryOperation {
+            operands: (left, right),
+        } = self;
+
+        f.write_fmt(format_args!(
+            "This binary operation is not supported for types '{:?}' and '{:?}'",
+            left, right
+        ))
+    }
+}
+
+impl Error for UnsupportedBinaryOperation {}

--- a/crates/why_lib/src/typechecker/typed_ast/expression/binary.rs
+++ b/crates/why_lib/src/typechecker/typed_ast/expression/binary.rs
@@ -134,7 +134,7 @@ mod tests {
         parser::ast::{BinaryExpression, BinaryOperator, Expression, Num},
         typechecker::{
             context::Context,
-            error::{TypeCheckError, TypeMismatch},
+            error::{TypeCheckError, TypeMismatch, UnsupportedBinaryOperation},
             types::Type,
             TypeCheckable,
         },
@@ -191,10 +191,9 @@ mod tests {
 
         assert_eq!(
             res,
-            Err(TypeCheckError::TypeMismatch(
-                TypeMismatch {
-                    expected: Type::Integer,
-                    actual: Type::FloatingPoint,
+            Err(TypeCheckError::UnsupportedBinaryOperation(
+                UnsupportedBinaryOperation {
+                    operands: (Type::Integer, Type::FloatingPoint)
                 },
                 Span::default()
             ))


### PR DESCRIPTION


<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#0r90IhOe5`](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/0r90IhOe5)

**feat(typechecker): add UnsupportedBinaryOperation error for binary ops**


Introduce a new error variant UnsupportedBinaryOperation to handle cases
where binary operations are not supported between given operand types.
Update the binary expression type checker to return this error when operand
types differ or when the operand type is not integer, floating point, or
boolean. This improves error reporting and enforces stricter type rules
for binary operations.

2 commit series (version 2)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 2/2 | [fix(typechecker): handle unsupported binary operations in type checker](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/0r90IhOe5/commit/cd3af02b-1c4e-4b43-87b5-66409265a9ba) | ⏳ |  |
| 1/2 | [feat(typechecker): add UnsupportedBinaryOperation error for binary ops](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/0r90IhOe5/commit/e253e252-1134-497e-819b-c69792a3daf9) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/h1ghbre4k3r/pesca-lang/reviews/0r90IhOe5)_
<!-- GitButler Review Footer Boundary Bottom -->
